### PR TITLE
Joystick name u16

### DIFF
--- a/core/src/Input/Joystick.h
+++ b/core/src/Input/Joystick.h
@@ -14,10 +14,12 @@ namespace Altseed {
 
 enum class JoystickType : int32_t {
     Other,
-    PS4 = 8200,
-    XBOX360 = 8199,
+    DualShock3 = 616,
+    DualShock4 = 1476,
+    DualShock4Slim = 2508,
+    XBOX360 = 654,
     JoyconL = 8198,
-    JoyconR = 8197,
+    JoyconR = 8199,
 };
 
 enum class JoystickButtonType : int32_t {
@@ -84,7 +86,7 @@ private:
     std::array<hid_device*, MAX_JOYSTICKS_NUM> handler_;
 
     std::array<JoystickType, MAX_JOYSTICKS_NUM> types_;
-    std::array<std::shared_ptr<wchar_t>, MAX_JOYSTICKS_NUM> names_;
+    std::array<std::shared_ptr<std::wstring>, MAX_JOYSTICKS_NUM> names_;
 
     std::array<std::array<bool, MAX_BUTTONS_NUM>, MAX_JOYSTICKS_NUM> currentHit_;
     std::array<std::array<bool, MAX_BUTTONS_NUM>, MAX_JOYSTICKS_NUM> preHit_;
@@ -115,7 +117,7 @@ public:
     float GetAxisStateByIndex(int32_t joystickIndex, int32_t axisIndex) const;
     float GetAxisStateByType(int32_t joystickIndex, JoystickAxisType type) const;
 
-    char16_t* GetJoystickName(int32_t index) const;
+    std::u16string GetJoystickName(int32_t index) const;
 
     //    for vibration only
 

--- a/core/src/Input/Keyboard.cpp
+++ b/core/src/Input/Keyboard.cpp
@@ -124,7 +124,6 @@ const int Keyboard::keyCodes[] = {GLFW_KEY_UNKNOWN,
                                   GLFW_KEY_RIGHT_CONTROL,
                                   GLFW_KEY_RIGHT_ALT,
                                   GLFW_KEY_RIGHT_SUPER,
-                                  GLFW_KEY_MENU,
                                   GLFW_KEY_MENU};
 
 bool Keyboard::Initialize(std::shared_ptr<Window>& window_) {

--- a/core/test/Joystick.cpp
+++ b/core/test/Joystick.cpp
@@ -1,4 +1,4 @@
-﻿#include <Core.h>
+#include <Core.h>
 #include <Input/Joystick.h>
 #include <gtest/gtest.h>
 #include <hidapi.h>
@@ -12,43 +12,14 @@ TEST(Joystick, Initialize) {
 
     EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
 
-    //    Altseed::JoystickManager::GetInstance()->PrintDevicesInfo();
-    //    temp();
-    Altseed::Joystick* joystick = new Altseed::Joystick();
+//    std::shared_ptr<Altseed::Joystick> joystick = std::make_shared<Altseed::Joystick>(Altseed::Joystick());
+    auto joystick = new Altseed::Joystick();
+
     joystick->Initialize(Altseed::JoystickType::JoyconL);
     for (int i = 0; i < 10; i++) {
-        printf("name: %ls", joystick->GetJoystickName(i));
-    }
-
-    std::chrono::system_clock::time_point start, end;  // 型は auto で可
-    start = std::chrono::system_clock::now();  // 計測開始時間
-    // 処理
-    end = std::chrono::system_clock::now();  // 計測終了時間
-    joystick->SetVibration(0, 462.457855f, 462.457855f, 0.981378f, 0.981378f, 1000);
-
-    //    joystick->SetVibration(0, 600.0f, 200.0f, 0.8f, 0.8f, 3000);
-
-    //    float pre_h = 0;
-    //    float pre_v = 0;
-    //
-    while (std::chrono::duration_cast<std::chrono::seconds>(end - start).count() <= 5.0f) {
-        joystick->RefreshVibrateState();
-
-        joystick->RefreshInputState();
-        //        float h = joystick->GetAxisState(0, Altseed::JoystickAxisType::LeftH);
-        //        float v = joystick->GetAxisState(0, Altseed::JoystickAxisType::LeftV);
-        //
-        //        if (pre_h == h && pre_v == v) {
-        //
-        //        } else {
-        //            printf("\nh: %f\n", h);
-        //            printf("v: %f\n", v);
-        //        }
-        //
-        //        pre_h = h;
-        //        pre_v = v;
-
-        end = std::chrono::system_clock::now();  // 計測終了時間
+        if (joystick->IsPresent(i))
+            printf("name: %s", joystick->GetJoystickName(i).c_str());
+        
     }
 
     Altseed::Core::Terminate();


### PR DESCRIPTION
AutoGeneratedCoreWrapperの生成したcbg_Joystick_GetJoystickNameで、u16string -> const char16_t * のキャストのところでエラーが出るかもしれません。