### PR TITLE
RenderedText (work in progress)

### DIFF
--- a/core/src/AutoGeneratedCoreWrapper.cpp
+++ b/core/src/AutoGeneratedCoreWrapper.cpp
@@ -1096,39 +1096,11 @@ CBGEXPORT Altseed::Vector2I_C CBGSTDCALL cbg_Font_CalcTextureSize(void* cbg_self
     return (cbg_ret);
 }
 
-CBGEXPORT Altseed::Color_C CBGSTDCALL cbg_Font_GetColor(void* cbg_self) {
-    auto cbg_self_ = (Altseed::Font*)(cbg_self);
-
-    Altseed::Color_C cbg_ret = cbg_self_->GetColor();
-    return (cbg_ret);
-}
-
-CBGEXPORT void CBGSTDCALL cbg_Font_SetColor(void* cbg_self, void* value) {
-    auto cbg_self_ = (Altseed::Font*)(cbg_self);
-
-    Altseed::Color_C cbg_arg0 = (*((Altseed::Color_C*)value));
-    cbg_self_->SetColor(cbg_arg0);
-}
-
 CBGEXPORT int32_t CBGSTDCALL cbg_Font_GetSize(void* cbg_self) {
     auto cbg_self_ = (Altseed::Font*)(cbg_self);
 
     int32_t cbg_ret = cbg_self_->GetSize();
     return cbg_ret;
-}
-
-CBGEXPORT int32_t CBGSTDCALL cbg_Font_GetWeight(void* cbg_self) {
-    auto cbg_self_ = (Altseed::Font*)(cbg_self);
-
-    int32_t cbg_ret = cbg_self_->GetWeight();
-    return cbg_ret;
-}
-
-CBGEXPORT void CBGSTDCALL cbg_Font_SetWeight(void* cbg_self, int32_t value) {
-    auto cbg_self_ = (Altseed::Font*)(cbg_self);
-
-    int32_t cbg_arg0 = value;
-    cbg_self_->SetWeight(cbg_arg0);
 }
 
 CBGEXPORT int32_t CBGSTDCALL cbg_Font_GetAscent(void* cbg_self) {

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -44,6 +44,8 @@ set(core_files
     Graphics/Renderer/RenderedCamera.cpp
     Graphics/Renderer/RenderedSprite.h
     Graphics/Renderer/RenderedSprite.cpp
+    Graphics/Renderer/RenderedText.h
+    Graphics/Renderer/RenderedText.cpp
     Graphics/Renderer/Renderer.h
     Graphics/Renderer/Renderer.cpp
     Graphics/Shader.h

--- a/core/src/Graphics/BuiltinShader.cpp
+++ b/core/src/Graphics/BuiltinShader.cpp
@@ -7,21 +7,21 @@ namespace Altseed {
 const char* SpriteUnlitVS = R"(
 cbuffer Consts : register(b0)
 {
-  float4x4 matView;
-  float4x4 matProjection;
+    float4x4 matView;
+    float4x4 matProjection;
 };
 
 struct VS_INPUT{
     float3 Position : POSITION0;
     float4 Color : COLOR0;
-	float2 UV1 : UV0;
-	float2 UV2 : UV1;
+    float2 UV1 : UV0;
+    float2 UV2 : UV1;
 };
 struct VS_OUTPUT{
     float4  Position : SV_POSITION;
     float4  Color    : COLOR0;
-	float2  UV1 : UV0;
-	float2  UV2 : UV1;
+    float2  UV1 : UV0;
+    float2  UV2 : UV1;
 };
     
 VS_OUTPUT main(VS_INPUT input){
@@ -32,8 +32,8 @@ VS_OUTPUT main(VS_INPUT input){
     pos = mul(matProjection, pos);
 
     output.Position = pos;
-	output.UV1 = input.UV1;
-	output.UV2 = input.UV2;
+    output.UV1 = input.UV1;
+    output.UV2 = input.UV2;
     output.Color = input.Color;
         
     return output;
@@ -47,14 +47,14 @@ struct PS_INPUT
 {
     float4  Position : SV_POSITION;
     float4  Color    : COLOR0;
-	float2  UV1 : UV0;
-	float2  UV2 : UV1;
+    float2  UV1 : UV0;
+    float2  UV2 : UV1;
 };
 float4 main(PS_INPUT input) : SV_TARGET 
 { 
-	float4 c;
-	c = mainTex.Sample(mainSamp, input.UV1) * input.Color;
-	return c;
+    float4 c;
+    c = mainTex.Sample(mainSamp, input.UV1) * input.Color;
+    return c;
 }
 )";
 
@@ -64,31 +64,25 @@ SamplerState mainSamp : register(s0);
 cbuffer Consts : register(b1)
 {
     float4 weight;
-    float4 color;
 };
 struct PS_INPUT
 {
     float4  Position : SV_POSITION;
     float4  Color    : COLOR0;
-	float2  UV1 : UV0;
-	float2  UV2 : UV1;
+    float2  UV1 : UV0;
+    float2  UV2 : UV1;
 };
 float4 main(PS_INPUT input) : SV_TARGET 
 { 
-	float4 c;
-	c = mainTex.Sample(mainSamp, input.UV1);
+    float4 c;
+    c = mainTex.Sample(mainSamp, input.UV1);
 
-	c = lerp(float4(0, 0, 0, 0), float4(1, 1, 1, 1), (c - weight) * 255);
-	c = lerp(float4(0, 0, 0, 0), float4(1, 1, 1, 1), c + weight);
-	if (c.r > 1)
-	{
-		return color;
-	}
-	if (c.r > 0) 
-	{
-		return color * c.r;
-	} 
-	return (float)0;
+    c = lerp(float4(0, 0, 0, 0), float4(1, 1, 1, 1), (c - weight.xxxx) * 255);
+    c = lerp(float4(0, 0, 0, 0), float4(1, 1, 1, 1), c + weight.xxxx);
+
+    if (c.r <= 0) discard;
+
+    return lerp(input.Color * c.r, input.Color, c.r > 1.0f);
 }
 )";
 

--- a/core/src/Graphics/Font.cpp
+++ b/core/src/Graphics/Font.cpp
@@ -20,18 +20,14 @@ Font::Font()
       lineGap_(0),
       scale_(0),
       fontinfo_(stbtt_fontinfo()),
-      color_(Color(255, 255, 255, 255)),
-      textureSize_(Vector2I(2000, 2000)),
-      weight_(0) {}
+      textureSize_(Vector2I(2000, 2000)) {}
 
 Font::Font(std::shared_ptr<Resources>& resources, std::shared_ptr<StaticFile>& file, stbtt_fontinfo fontinfo, int32_t size)
     : resources_(resources),
       file_(file),
       fontinfo_(fontinfo),
       size_(size),
-      color_(Color(255, 255, 255, 255)),
-      textureSize_(Vector2I(2000, 2000)),
-      weight_(0) {
+      textureSize_(Vector2I(2000, 2000)) {
     scale_ = stbtt_ScaleForPixelHeight(&fontinfo_, size_);
 
     stbtt_GetFontVMetrics(&fontinfo_, &ascent_, &descent_, &lineGap_);

--- a/core/src/Graphics/Font.h
+++ b/core/src/Graphics/Font.h
@@ -43,7 +43,6 @@ private:
     int32_t ascent_, descent_, lineGap_;
 
     int32_t size_;
-    Color color_;
     float weight_;
 
     std::shared_ptr<StaticFile> file_;
@@ -60,12 +59,6 @@ protected:
 public:
     Font(std::shared_ptr<Resources>& resources, std::shared_ptr<StaticFile>& file, stbtt_fontinfo fontinfo, int32_t size);
     virtual ~Font();
-
-    virtual void SetColor(Color color) { color_ = color; }
-    virtual Color GetColor() { return color_; }
-
-	virtual void SetWeight(float weight) { weight_ = weight; }
-    virtual float GetWeight() { return weight_; }
 
     virtual int32_t GetSize() { return size_; }
     virtual int32_t GetAscent() { return ascent_; }

--- a/core/src/Graphics/ImageFont.h
+++ b/core/src/Graphics/ImageFont.h
@@ -22,12 +22,6 @@ public:
     ImageFont(std::shared_ptr<Font> baseFont);
     virtual ~ImageFont();
 
-    void SetColor(Color color) override { baseFont_->SetColor(color); }
-    Color GetColor() override { return baseFont_->GetColor(); }
-
-    virtual void SetWeight(float weight) override { baseFont_->SetWeight(weight); }
-    virtual float GetWeight() override { return baseFont_->GetWeight(); }
-
     virtual int32_t GetSize() override { return baseFont_->GetSize(); }
     virtual int32_t GetAscent() override { return baseFont_->GetAscent(); }
     virtual int32_t GetDescent() override { return baseFont_->GetDescent(); }

--- a/core/src/Graphics/Renderer/RenderedText.cpp
+++ b/core/src/Graphics/Renderer/RenderedText.cpp
@@ -1,0 +1,22 @@
+#include "RenderedText.h"
+#include "../../Math/Vector4F.h"
+#include "../Graphics.h"
+#include "../BuiltinShader.h"
+
+namespace Altseed {
+
+std::shared_ptr<RenderedText> RenderedText::Create() {
+    auto t = MakeAsdShared<RenderedText>();
+
+    auto shader = Graphics::GetInstance()->GetBuiltinShader()->Create(BuiltinShaderType::FontUnlitPS);
+    auto material = Altseed::MakeAsdShared<Altseed::Material>();
+    material->SetShader(shader);
+    
+    t->SetMaterial(material);
+    t->SetText(u"");
+    t->SetColor(Color(255, 255, 255, 255));
+
+    return t;
+}
+
+}  // namespace Altseed

--- a/core/src/Graphics/Renderer/RenderedText.h
+++ b/core/src/Graphics/Renderer/RenderedText.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "Rendered.h"
+
+#include <stdio.h>
+#include <memory>
+#include "../Color.h"
+#include "../Font.h"
+#include "../Material.h"
+
+namespace Altseed {
+
+class RenderedText : public Rendered {
+private:
+    std::shared_ptr<Material> material_;
+    std::shared_ptr<Font> font_;
+    std::u16string text_;
+    Color color_;
+    float weight_;
+
+
+public:
+    static std::shared_ptr<RenderedText> Create();
+
+    float GetWeight() const { return weight_; }
+
+    void SetWeight(float weight) { weight_ = weight; }
+
+    std::shared_ptr<Material> GetMaterial() const { return material_; }
+
+    void SetMaterial(const std::shared_ptr<Material>& material) { material_ = material; }
+
+    std::shared_ptr<Font> GetFont() const { return font_; }
+
+    void SetFont(const std::shared_ptr<Font>& font) { font_ = font; }
+
+    const char16_t* GetText() const { return text_.c_str(); }
+
+    void SetText(const char16_t* text) { text_ = std::u16string(text); }
+
+    Color GetColor() const { return color_; }
+
+    void SetColor(const Color color) { color_ = color; }
+};
+
+}  // namespace Altseed

--- a/core/src/Graphics/Renderer/Renderer.h
+++ b/core/src/Graphics/Renderer/Renderer.h
@@ -11,10 +11,9 @@ namespace Altseed {
 
 class Texture2D;
 class RenderedSprite;
+class RenderedText;
 class RenderedCamera;
 class CommandList;
-class RenderedSprite;
-class RenderedCamera;
 class Window;
 
 class Renderer : public BaseObject {
@@ -47,6 +46,8 @@ public:
             const std::shared_ptr<Material>& material = nullptr);
 
     void DrawSprite(std::shared_ptr<RenderedSprite> sprite);
+
+    void DrawText(std::shared_ptr<RenderedText> text);
 
     void Render(std::shared_ptr<CommandList> commandList);
 

--- a/core/test/Font.cpp
+++ b/core/test/Font.cpp
@@ -21,10 +21,6 @@
 #include "Tool/Tool.h"
 
 TEST(Font, Basic) {
-#if defined(__APPLE__) || defined(__linux__)
-    return;
-#endif
-
     EXPECT_TRUE(Altseed::Core::Initialize(u"test", 1280, 720, Altseed::Configuration::Create()));
 
     int count = 0;
@@ -70,18 +66,11 @@ TEST(Font, Basic) {
         if (i != std::char_traits<char16_t>::length(text) - 1) position += Altseed::Vector2F(font->GetKerning(character, text[i + 1]), 0);
     }
 
+    float weight = 0.0f;
+    material->SetVector4F(u"weight", Altseed::Vector4F(0.5f - weight / 255, 0, 0, 0));
+
     while (count++ < 100 && instance->DoEvents()) {
         EXPECT_TRUE(instance->BeginFrame());
-
-        material->SetVector4F(
-                u"weight",
-                Altseed::Vector4F(
-                        0.5f - font->GetWeight() / 255,
-                        0.5f - font->GetWeight() / 255,
-                        0.5f - font->GetWeight() / 255,
-                        0.5f - font->GetWeight() / 255));
-
-        material->SetVector4F(u"color", Altseed::Vector4F(font->GetColor().R, font->GetColor().G, font->GetColor().B, font->GetColor().A));
 
         for (auto& s : sprites) {
             Altseed::Renderer::GetInstance()->DrawSprite(s);
@@ -94,10 +83,6 @@ TEST(Font, Basic) {
 }
 
 TEST(Font, Weight) {
-#if defined(__APPLE__) || defined(__linux__)
-    return;
-#endif
-
     EXPECT_TRUE(Altseed::Core::Initialize(u"test", 1280, 720, Altseed::Configuration::Create()));
 
     int count = 0;
@@ -144,21 +129,11 @@ TEST(Font, Weight) {
     }
 
     while (count++ < 100 && instance->DoEvents()) {
-        font->SetWeight(count / 20.0f - 2.5f);
+        auto weight = count / 20.0f - 2.5f;
+
         EXPECT_TRUE(instance->BeginFrame());
 
-        material->SetVector4F(
-                u"weight",
-                Altseed::Vector4F(
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f));
-
-        material->SetVector4F(
-                u"color",
-                Altseed::Vector4F(
-                        font->GetColor().R / 255.f, font->GetColor().G / 255.f, font->GetColor().B / 255.f, font->GetColor().A / 255.f));
+        material->SetVector4F(u"weight", Altseed::Vector4F(0.5f - weight / 255.0f, 0, 0, 0));
 
         for (auto& s : sprites) {
             Altseed::Renderer::GetInstance()->DrawSprite(s);
@@ -170,88 +145,68 @@ TEST(Font, Weight) {
     Altseed::Core::Terminate();
 }
 
-TEST(Font, Color) {
-#if defined(__APPLE__) || defined(__linux__)
-    return;
-#endif
+// TEST(Font, Color) {
+//     EXPECT_TRUE(Altseed::Core::Initialize(u"test", 1280, 720, Altseed::Configuration::Create()));
 
-    EXPECT_TRUE(Altseed::Core::Initialize(u"test", 1280, 720, Altseed::Configuration::Create()));
+//     int count = 0;
 
-    int count = 0;
+//     auto instance = Altseed::Graphics::GetInstance();
 
-    auto instance = Altseed::Graphics::GetInstance();
+//     auto font = Altseed::Font::LoadDynamicFont(u"TestData/Font/GenYoMinJP-Bold.ttf", 100);
 
-    auto font = Altseed::Font::LoadDynamicFont(u"TestData/Font/GenYoMinJP-Bold.ttf", 100);
+//     auto shader = instance->GetBuiltinShader()->Create(Altseed::BuiltinShaderType::FontUnlitPS);
+//     auto material = Altseed::MakeAsdShared<Altseed::Material>();
+//     material->SetShader(shader);
 
-    auto shader = instance->GetBuiltinShader()->Create(Altseed::BuiltinShaderType::FontUnlitPS);
-    auto material = Altseed::MakeAsdShared<Altseed::Material>();
-    material->SetShader(shader);
+//     std::vector<std::shared_ptr<Altseed::RenderedSprite>> sprites;
+//     const char16_t* text = u"こんにちは！ Hello World";
+//     Altseed::Vector2F position(100, 100);
+//     for (int32_t i = 0; i < std::char_traits<char16_t>::length(text); i++) {
+//         int32_t character = 0;
 
-    std::vector<std::shared_ptr<Altseed::RenderedSprite>> sprites;
-    const char16_t* text = u"こんにちは！ Hello World";
-    Altseed::Vector2F position(100, 100);
-    for (int32_t i = 0; i < std::char_traits<char16_t>::length(text); i++) {
-        int32_t character = 0;
+//         char32_t tmp = 0;
+//         Altseed::ConvChU16ToU32({text[i], text[i + 1]}, tmp);
+//         character = (int32_t)tmp;
+//         if (text[i] >= 0xD800 && text[i] <= 0xDBFF) {
+//             i++;
+//         }
 
-        char32_t tmp = 0;
-        Altseed::ConvChU16ToU32({text[i], text[i + 1]}, tmp);
-        character = (int32_t)tmp;
-        if (text[i] >= 0xD800 && text[i] <= 0xDBFF) {
-            i++;
-        }
+//         auto glyph = font->GetGlyph(character);
+//         if (glyph == nullptr) continue;
 
-        auto glyph = font->GetGlyph(character);
-        if (glyph == nullptr) continue;
+//         auto tempPosition = position + glyph->GetOffset().To2F() + Altseed::Vector2F(0, font->GetAscent());
+//         auto sprite = Altseed::RenderedSprite::Create();
+//         sprite->SetMaterial(material);
+//         sprite->SetTexture(font->GetFontTexture(glyph->GetTextureIndex()));
 
-        auto tempPosition = position + glyph->GetOffset().To2F() + Altseed::Vector2F(0, font->GetAscent());
-        auto sprite = Altseed::RenderedSprite::Create();
-        sprite->SetMaterial(material);
-        sprite->SetTexture(font->GetFontTexture(glyph->GetTextureIndex()));
+//         Altseed::Matrix44F trans;
+//         trans.SetTranslation(tempPosition.X, tempPosition.Y, 0);
+//         sprite->SetTransform(trans);
 
-        Altseed::Matrix44F trans;
-        trans.SetTranslation(tempPosition.X, tempPosition.Y, 0);
-        sprite->SetTransform(trans);
+//         sprite->SetSrc(Altseed::RectF(glyph->GetPosition().X, glyph->GetPosition().Y, glyph->GetSize().X, glyph->GetSize().Y));
+//         sprites.push_back(sprite);
 
-        sprite->SetSrc(Altseed::RectF(glyph->GetPosition().X, glyph->GetPosition().Y, glyph->GetSize().X, glyph->GetSize().Y));
-        sprites.push_back(sprite);
+//         position += Altseed::Vector2F(glyph->GetGlyphWidth(), 0);
 
-        position += Altseed::Vector2F(glyph->GetGlyphWidth(), 0);
+//         if (i != std::char_traits<char16_t>::length(text) - 1) position += Altseed::Vector2F(font->GetKerning(character, text[i + 1]), 0);
+//     }
 
-        if (i != std::char_traits<char16_t>::length(text) - 1) position += Altseed::Vector2F(font->GetKerning(character, text[i + 1]), 0);
-    }
+//     float weight = 0.0f;
+//     material->SetVector4F(u"weight", Altseed::Vector4F(0.5f - weight / 255.0f, 0, 0, 0));
 
-    while (count++ < 255 && instance->DoEvents()) {
-        font->SetColor(Altseed::Color(255 - count, count, count, 255));
-        EXPECT_TRUE(instance->BeginFrame());
+//     while (count++ < 255 && instance->DoEvents()) {
+//         EXPECT_TRUE(instance->BeginFrame());
+//         for (auto& s : sprites) {
+//             Altseed::Renderer::GetInstance()->DrawSprite(s);
+//         }
+//         Altseed::Renderer::GetInstance()->Render(instance->GetCommandList());
+//         EXPECT_TRUE(instance->EndFrame());
+//     }
 
-        material->SetVector4F(
-                u"weight",
-                Altseed::Vector4F(
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f));
-
-        material->SetVector4F(
-                u"color",
-                Altseed::Vector4F(
-                        font->GetColor().R / 255.f, font->GetColor().G / 255.f, font->GetColor().B / 255.f, font->GetColor().A / 255.f));
-
-        for (auto& s : sprites) {
-            Altseed::Renderer::GetInstance()->DrawSprite(s);
-        }
-        Altseed::Renderer::GetInstance()->Render(instance->GetCommandList());
-        EXPECT_TRUE(instance->EndFrame());
-    }
-
-    Altseed::Core::Terminate();
-}
+//     Altseed::Core::Terminate();
+// }
 
 TEST(Font, Surrogate) {
-#if defined(__APPLE__) || defined(__linux__)
-    return;
-#endif
-
     EXPECT_TRUE(Altseed::Core::Initialize(u"test", 1280, 720, Altseed::Configuration::Create()));
 
     int count = 0;
@@ -296,21 +251,11 @@ TEST(Font, Surrogate) {
         if (i != std::char_traits<char16_t>::length(text) - 1) position += Altseed::Vector2F(font->GetKerning(character, text[i + 1]), 0);
     }
 
+    float weight = 0.0f;
+    material->SetVector4F(u"weight", Altseed::Vector4F(0.5f - weight / 255.0f, 0.0f, 0.0f, 0.0f));
+
     while (count++ < 255 && instance->DoEvents()) {
         EXPECT_TRUE(instance->BeginFrame());
-
-        material->SetVector4F(
-                u"weight",
-                Altseed::Vector4F(
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f));
-
-        material->SetVector4F(
-                u"color",
-                Altseed::Vector4F(
-                        font->GetColor().R / 255.f, font->GetColor().G / 255.f, font->GetColor().B / 255.f, font->GetColor().A / 255.f));
 
         for (auto& s : sprites) {
             Altseed::Renderer::GetInstance()->DrawSprite(s);
@@ -323,10 +268,6 @@ TEST(Font, Surrogate) {
 }
 
 TEST(Font, ImageFont) {
-#if defined(__APPLE__) || defined(__linux__)
-    return;
-#endif
-
     EXPECT_TRUE(Altseed::Core::Initialize(u"test", 1280, 720, Altseed::Configuration::Create()));
 
     int count = 0;
@@ -391,21 +332,11 @@ TEST(Font, ImageFont) {
         if (i != std::char_traits<char16_t>::length(text) - 1) position += Altseed::Vector2F(font->GetKerning(character, text[i + 1]), 0);
     }
 
+    float weight = 0.0f;
+    material->SetVector4F(u"weight", Altseed::Vector4F(0.5f - weight / 255.0f, 0, 0, 0));
+
     while (count++ < 255 && instance->DoEvents()) {
         EXPECT_TRUE(instance->BeginFrame());
-
-        material->SetVector4F(
-                u"weight",
-                Altseed::Vector4F(
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f,
-                        0.5f - font->GetWeight() / 255.0f));
-
-        material->SetVector4F(
-                u"color",
-                Altseed::Vector4F(
-                        font->GetColor().R / 255.f, font->GetColor().G / 255.f, font->GetColor().B / 255.f, font->GetColor().A / 255.f));
 
         for (auto& s : sprites) {
             Altseed::Renderer::GetInstance()->DrawSprite(s);

--- a/core/test/Graphics.cpp
+++ b/core/test/Graphics.cpp
@@ -5,10 +5,14 @@
 
 #include <memory>
 
+#include "Math/Matrix44F.h"
 #include "Graphics/Camera.h"
 #include "Graphics/CommandList.h"
+#include "Graphics/Font.h"
+#include "Graphics/Color.h"
 #include "Graphics/Renderer/RenderedCamera.h"
 #include "Graphics/Renderer/RenderedSprite.h"
+#include "Graphics/Renderer/RenderedText.h"
 #include "Graphics/Renderer/Renderer.h"
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
 #include "Tool/Tool.h"
@@ -224,6 +228,77 @@ TEST(Graphics, SpriteTexture) {
 
         Altseed::Renderer::GetInstance()->DrawSprite(s1);
         Altseed::Renderer::GetInstance()->DrawSprite(s2);
+
+        Altseed::Renderer::GetInstance()->Render(instance->GetCommandList());
+
+        EXPECT_TRUE(instance->EndFrame());
+    }
+
+    Altseed::Core::Terminate();
+}
+
+TEST(Graphics, RenderedText) {
+    EXPECT_TRUE(Altseed::Core::Initialize(u"SpriteTexture", 1280, 720, Altseed::Configuration::Create()));
+
+    auto font = Altseed::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 100);
+
+    std::vector<std::shared_ptr<Altseed::RenderedText>> texts;
+
+    {
+        auto t = Altseed::RenderedText::Create();
+        t->SetFont(font);
+        t->SetText(u"Hello, world! こんにちは");
+        t->SetTransform(Altseed::Matrix44F().SetTranslation(0, 0, 0));
+        texts.push_back(t);
+    }
+    
+    {
+        auto t = Altseed::RenderedText::Create();
+        t->SetFont(font);
+        t->SetText(u"色を指定する。");
+        t->SetColor(Altseed::Color(0, 0, 255, 255));
+        t->SetTransform(Altseed::Matrix44F().SetTranslation(0, 100.0f, 0));
+        texts.push_back(t);
+    }
+
+    auto weitText = Altseed::RenderedText::Create();
+    {
+        weitText->SetText(u"太さを指定する。");
+        weitText->SetFont(font);
+        weitText->SetTransform(Altseed::Matrix44F().SetTranslation(0, 200.0f, 0));
+        texts.push_back(weitText);
+    }
+
+    auto fontGenyomin = Altseed::Font::LoadDynamicFont(u"TestData/Font/GenYoMinJP-Bold.ttf", 100);
+    {
+        auto t = Altseed::RenderedText::Create();
+        t->SetFont(fontGenyomin);
+        t->SetText(u"𠀋 𡈽 𡌛 𡑮 𡢽 𠮟 𡚴 𡸴 𣇄 𣗄 𣜿 𣝣 𣳾 𤟱 𥒎 𥔎 𥝱 𥧄 𥶡 𦫿 𦹀 𧃴 𧚄 𨉷");
+        t->SetTransform(Altseed::Matrix44F().SetTranslation(0, 300.0f, 0));
+        texts.push_back(t);
+    }
+
+    auto rotatedText = Altseed::RenderedText::Create();
+    {
+        rotatedText->SetFont(font);
+        rotatedText->SetText(u"くるくるまわる");
+        texts.push_back(rotatedText);
+    }
+
+    auto rotatedTrans = Altseed::Matrix44F().SetTranslation(600.0f, 400.0f, 0.0f);
+    Altseed::Matrix44F rotatedRot;
+
+    auto instance = Altseed::Graphics::GetInstance();
+
+    for (int count = 0; count++ < 100 && instance->DoEvents();) {
+        EXPECT_TRUE(instance->BeginFrame());
+
+        weitText->SetWeight(count / 20.0f - 2.5f);
+        rotatedText->SetTransform(rotatedTrans * rotatedRot.SetRotationZ(4 * count * M_PI / 180.0));
+
+        for(const auto& t : texts) {
+            Altseed::Renderer::GetInstance()->DrawText(t);
+        }
 
         Altseed::Renderer::GetInstance()->Render(instance->GetCommandList());
 

--- a/scripts/bindings/graphics.py
+++ b/scripts/bindings/graphics.py
@@ -177,92 +177,6 @@ with Material as class_:
         prop.has_getter = True
         prop.has_setter = True
 
-Rendered = cbg.Class('Altseed', 'Rendered')
-with Rendered as class_:
-    class_.brief('ja', '描画されるオブジェクトの基本クラスを表します')
-    with class_.add_property(Matrix44F, 'Transform') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', '変換行列を取得または設定します。')
-        prop.has_getter = True
-        prop.has_setter = True
-
-RenderedSprite = cbg.Class('Altseed', 'RenderedSprite')
-with RenderedSprite as class_:
-    class_.base_class = Rendered
-    class_.brief = cbg.Description()
-    class_.brief.add('ja', 'スプライトのクラス')
-    with class_.add_func('Create') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', 'スプライトを作成します。')
-        func.return_value.type_ = RenderedSprite
-        func.is_static = True
-    with class_.add_property(Texture2D, 'Texture') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', 'テクスチャを取得または設定します。')
-        prop.has_getter = True
-        prop.has_setter = True
-    with class_.add_property(RectF, 'Src') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', '描画範囲を取得または設定します。')
-        prop.has_getter = True
-        prop.has_setter = True
-    with class_.add_property(Matrix44F, 'Transform') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', '変換行列を取得または設定します。')
-        prop.has_getter = True
-        prop.has_setter = True
-    with class_.add_property(Material, 'Material') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', 'マテリアルを取得または設定します。')
-        prop.has_getter = True
-        prop.has_setter = True
-
-RenderedCamera = cbg.Class('Altseed', 'RenderedCamera')
-with RenderedCamera as class_:
-    class_.base_class = Rendered
-    class_.brief = cbg.Description()
-    class_.brief.add('ja', 'カメラのクラス')
-
-Renderer = cbg.Class('Altseed', 'Renderer')
-with Renderer as class_:
-    class_.is_public = True
-    class_.brief = cbg.Description()
-    class_.brief.add('ja', 'レンダラのクラス')
-    with class_.add_func('GetInstance') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', 'インスタンスを取得します。')
-        func.return_value.type_ = Renderer
-        func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '使用するインスタンス')
-        func.is_public = False
-        func.is_static = True
-    with class_.add_func('DrawSprite') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', 'スプライトを描画します。')
-        func.add_arg(RenderedSprite, 'sprite')
-        func.is_public = True  # TODO：Engine側できちんと隠す
-    with class_.add_func('Render') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', 'コマンドリストを描画します。')
-        with func.add_arg(CommandList, 'commandList') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', 'コマンドリスト')
-        func.is_public = True  # TODO：Engine側できちんと隠す
-    with class_.add_func('DrawPolygon') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', 'ポリゴンを描画します')
-        with func.add_arg(VertexArray, 'vertexBuffer') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', '頂点バッファ')
-        with func.add_arg(Int32Array, 'indexBuffer') as arg:
-            arg.brief = cbg.Description()
-        with func.add_arg(Texture2D, 'texture') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', 'テクスチャ')
-        with func.add_arg(Material, 'material') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', 'マテリアル')
-
 WritingDirection = cbg.Enum('Altseed', 'WritingDirection')
 with WritingDirection as enum_:
     enum_.add('Vertical')
@@ -301,20 +215,10 @@ Font = cbg.Class('Altseed', 'Font', cbg.CacheMode.ThreadSafeCache)
 with Font as class_:
     class_.brief = cbg.Description()
     class_.brief.add('ja', 'フォント')
-    with class_.add_property(Color, 'Color') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', 'フォントの色を取得・設定する')
-        prop.has_getter = True
-        prop.has_setter = True
     with class_.add_property(int, 'Size') as prop:
         prop.brief = cbg.Description()
         prop.brief.add('ja', 'フォントのサイズを取得する')
         prop.has_getter = True
-    with class_.add_property(int, 'Weight') as prop:
-        prop.brief = cbg.Description()
-        prop.brief.add('ja', 'フォントの太さを取得・設定する')
-        prop.has_getter = True
-        prop.has_setter = True
     with class_.add_property(int, 'Ascent') as prop:
         prop.brief = cbg.Description()
         prop.brief.add('ja', 'フォントのベースラインからトップラインまでの距離を取得する')
@@ -439,3 +343,133 @@ with ImageFont as class_:
             arg.brief = cbg.Description()
             arg.brief.add('ja', '文字')
         func.is_public = True
+
+
+Rendered = cbg.Class('Altseed', 'Rendered')
+with Rendered as class_:
+    class_.brief('ja', '描画されるオブジェクトの基本クラスを表します')
+    with class_.add_property(Matrix44F, 'Transform') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '変換行列を取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+RenderedSprite = cbg.Class('Altseed', 'RenderedSprite')
+with RenderedSprite as class_:
+    class_.base_class = Rendered
+    class_.brief = cbg.Description()
+    class_.brief.add('ja', 'スプライトのクラス')
+    with class_.add_func('Create') as func:
+        func.brief = cbg.Description()
+        func.brief.add('ja', 'スプライトを作成します。')
+        func.return_value.type_ = RenderedSprite
+        func.is_static = True
+    with class_.add_property(Texture2D, 'Texture') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', 'テクスチャを取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+    with class_.add_property(RectF, 'Src') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '描画範囲を取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+    with class_.add_property(Matrix44F, 'Transform') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '変換行列を取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+    with class_.add_property(Material, 'Material') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', 'マテリアルを取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+RenderedText = cbg.Class('Altseed', 'RenderedText')
+with RenderedText as class_:
+    class_.base_class = Rendered
+    class_.brief = cbg.Description()
+    class_.brief.add('ja', 'カメラのクラス')
+
+    with class_.add_property(Matrix44F, 'Transform') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '変換行列を取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+    with class_.add_property(Material, 'Material') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', 'マテリアルを取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+    with class_.add_property(ctypes.c_wchar_p, 'Text') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', 'テキストを取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+    with class_.add_property(Font, 'Font') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', 'フォントを取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+    with class_.add_property(float, 'Weight') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '文字の太さを取得または設定します。(0 ~ 255)')
+        prop.has_getter = True
+        prop.has_setter = True
+
+    with class_.add_property(Color, 'Color') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '色を取得または設定します。')
+        prop.has_getter = True
+        prop.has_setter = True
+
+
+RenderedCamera = cbg.Class('Altseed', 'RenderedCamera')
+with RenderedCamera as class_:
+    class_.base_class = Rendered
+    class_.brief = cbg.Description()
+    class_.brief.add('ja', 'カメラのクラス')
+
+Renderer = cbg.Class('Altseed', 'Renderer')
+with Renderer as class_:
+    class_.is_public = True
+    class_.brief = cbg.Description()
+    class_.brief.add('ja', 'レンダラのクラス')
+    with class_.add_func('GetInstance') as func:
+        func.brief = cbg.Description()
+        func.brief.add('ja', 'インスタンスを取得します。')
+        func.return_value.type_ = Renderer
+        func.return_value.brief = cbg.Description()
+        func.return_value.brief.add('ja', '使用するインスタンス')
+        func.is_public = False
+        func.is_static = True
+    with class_.add_func('DrawSprite') as func:
+        func.brief = cbg.Description()
+        func.brief.add('ja', 'スプライトを描画します。')
+        func.add_arg(RenderedSprite, 'sprite')
+        func.is_public = True  # TODO：Engine側できちんと隠す
+    with class_.add_func('Render') as func:
+        func.brief = cbg.Description()
+        func.brief.add('ja', 'コマンドリストを描画します。')
+        with func.add_arg(CommandList, 'commandList') as arg:
+            arg.brief = cbg.Description()
+            arg.brief.add('ja', 'コマンドリスト')
+        func.is_public = True  # TODO：Engine側できちんと隠す
+    with class_.add_func('DrawPolygon') as func:
+        func.brief = cbg.Description()
+        func.brief.add('ja', 'ポリゴンを描画します')
+        with func.add_arg(VertexArray, 'vertexBuffer') as arg:
+            arg.brief = cbg.Description()
+            arg.brief.add('ja', '頂点バッファ')
+        with func.add_arg(Int32Array, 'indexBuffer') as arg:
+            arg.brief = cbg.Description()
+        with func.add_arg(Texture2D, 'texture') as arg:
+            arg.brief = cbg.Description()
+            arg.brief.add('ja', 'テクスチャ')
+        with func.add_arg(Material, 'material') as arg:
+            arg.brief = cbg.Description()
+            arg.brief.add('ja', 'マテリアル')


### PR DESCRIPTION
これした時に
```
./Altseed_Core_Test --gtest_filter='Graphics.Rendered*'
```

## 正しい結果
クリア処理入ってないのは置いておいて
<img width="1392" alt="スクリーンショット 2020-03-06 1 07 55" src="https://user-images.githubusercontent.com/29581531/76000369-f15d6280-5f46-11ea-9058-950c7b8bc34a.png">

## 同じ実行ファイルで頻繁にこうなる
<img width="1392" alt="スクリーンショット 2020-03-06 1 00 20" src="https://user-images.githubusercontent.com/29581531/76000444-0df99a80-5f47-11ea-9ff9-44edbb728559.png">

## セグフォが発生することもある
```
Altseed_Core_Test(85382,0x114208d40) malloc: Incorrect checksum for freed object 0x7f955c6199c0: probably modified after being freed.
Corrupt value: 0x7fff8f2b17f8
Altseed_Core_Test(85382,0x114208d40) malloc: *** set a breakpoint in malloc_error_break to debug
fish: './Altseed_Core_Test --gtest_fil…' terminated by signal SIGABRT (Abort)
```