### PR TITLE
Implement PostEffect

### DIFF
--- a/core/src/Core.cpp
+++ b/core/src/Core.cpp
@@ -167,6 +167,7 @@ bool Core::DoEvent() {
     Altseed::Keyboard::GetInstance()->RefleshKeyStates();
     Altseed::Mouse::GetInstance()->RefreshInputState();
     Altseed::Joystick::GetInstance()->RefreshInputState();
+    Renderer::GetInstance()->DoEvent();
 
     Core::instance->fps_->Update();
 

--- a/core/src/Graphics/CommandList.cpp
+++ b/core/src/Graphics/CommandList.cpp
@@ -4,6 +4,7 @@
 #include "BuiltinShader.h"
 #include "FrameDebugger.h"
 #include "RenderTexture.h"
+#include "../Logger/Log.h"
 
 namespace Altseed {
 
@@ -157,9 +158,7 @@ void CommandList::StartFrame() {
 
 void CommandList::EndFrame() {
     if (isInRenderPass_) {
-        currentCommandList_->EndRenderPass();
-        isInRenderPass_ = false;
-        currentRenderPass_ = nullptr;
+        EndRenderPass();
     }
     currentCommandList_->End();
 
@@ -167,6 +166,61 @@ void CommandList::EndFrame() {
 }
 
 void CommandList::SetScissor(const RectI& scissor) { currentCommandList_->SetScissor(scissor.X, scissor.Y, scissor.Width, scissor.Height); }
+
+void CommandList::BeginRenderPass(std::shared_ptr<RenderTexture> target, std::shared_ptr<LLGI::RenderPass> renderPass) {
+    if (isInRenderPass_) {
+        Log::GetInstance()->Error(LogCategory::Core, u"CommandList::BeginRenderPass: invalid CommandList state");
+        return;
+    }
+
+    currentCommandList_->BeginRenderPass(renderPass.get());
+    currentRenderPass_ = renderPass;
+    currentRenderTarget_ = target;
+    isInRenderPass_ = true;
+
+    FrameDebugger::GetInstance()->SetRenderTarget(target);
+    FrameDebugger::GetInstance()->BeginRenderPass();
+}
+
+void CommandList::EndRenderPass() {
+    if (!isInRenderPass_) {
+        Log::GetInstance()->Error(LogCategory::Core, u"CommandList::EndRenderPass: invalid CommandList state");
+        return;
+    }
+    
+    currentCommandList_->EndRenderPass();
+    FrameDebugger::GetInstance()->EndRenderPass();
+    isInRenderPass_ = false;
+    currentRenderTarget_ = nullptr;
+    currentRenderPass_ = nullptr;
+}
+
+void CommandList::PauseRenderPass() {
+    if (!isInRenderPass_) {
+        Log::GetInstance()->Error(LogCategory::Core, u"CommandList::EndRenderPass: invalid CommandList state");
+        return;
+    }
+
+    currentCommandList_->EndRenderPass();
+    FrameDebugger::GetInstance()->EndRenderPass();
+    isInRenderPass_ = false;
+}
+
+void CommandList::ResumeRenderPass() {
+    if (isInRenderPass_ || currentRenderPass_ == nullptr || currentRenderTarget_ == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"CommandList::ResumeRenderPass: invalid CommandList state");
+        return;
+    }
+
+    currentRenderPass_->SetIsColorCleared(false);
+    currentRenderPass_->SetIsDepthCleared(false);
+
+    currentCommandList_->BeginRenderPass(currentRenderPass_.get());
+    isInRenderPass_ = true;
+
+    FrameDebugger::GetInstance()->SetRenderTarget(currentRenderTarget_);
+    FrameDebugger::GetInstance()->BeginRenderPass();
+}
 
 void CommandList::SetRenderTarget(std::shared_ptr<RenderTexture> target, const RenderPassParameter& renderPassParameter) {
     auto it = renderPassCaches_.find(target);
@@ -190,17 +244,11 @@ void CommandList::SetRenderTarget(std::shared_ptr<RenderTexture> target, const R
     renderPassCaches_[target].Stored->SetIsDepthCleared(renderPassParameter.ColorCare == RenderTargetCareType::Clear);
     renderPassCaches_[target].Stored->SetClearColor(renderPassParameter.ClearColor.ToLL());
 
-    if (isInRenderPass_) {
-        currentCommandList_->EndRenderPass();
-        FrameDebugger::GetInstance()->EndRenderPass();
+    if (isInRenderPass_){
+        EndRenderPass();
     }
-
-    currentCommandList_->BeginRenderPass(renderPassCaches_[target].Stored.get());
-    currentRenderPass_ = renderPassCaches_[target].Stored;
-    isInRenderPass_ = true;
-
-    FrameDebugger::GetInstance()->SetRenderTarget(target);
-    FrameDebugger::GetInstance()->BeginRenderPass();
+    
+    BeginRenderPass(target, renderPassCaches_[target].Stored);
 }
 
 void CommandList::RenderToRenderTarget(std::shared_ptr<Material> material) {
@@ -244,16 +292,10 @@ void CommandList::SetRenderTargetWithScreen() {
     }
 
     if (isInRenderPass_) {
-        currentCommandList_->EndRenderPass();
-        FrameDebugger::GetInstance()->EndRenderPass();
+        EndRenderPass();
     }
 
-    currentCommandList_->BeginRenderPass(r.get());
-    currentRenderPass_ = r;
-    isInRenderPass_ = true;
-
-    FrameDebugger::GetInstance()->SetRenderTargetWithRealScreen();
-    FrameDebugger::GetInstance()->BeginRenderPass();
+    BeginRenderPass(internalScreen_, r);
 }
 
 void CommandList::PresentInternal() {
@@ -325,6 +367,30 @@ void CommandList::StoreUniforms(
     commandList->GetLL()->SetConstantBuffer(cb, shaderStage);
 
     LLGI::SafeRelease(cb);
+}
+
+void CommandList::CopyTexture(std::shared_ptr<RenderTexture> src, std::shared_ptr<RenderTexture> dst) {
+    auto srcSize = src->GetSize();
+    auto dstSize = dst->GetSize();
+
+    if (srcSize != dstSize) {
+        Log::GetInstance()->Error(LogCategory::Core, u"CommandList::CopyTexture failed, src's size ({}, {}) is not equal to dst's size ({}, {})", srcSize.X, srcSize.Y, dstSize.X, dstSize.Y);
+        return;
+    }
+
+    if(isInRenderPass_) {
+        PauseRenderPass();
+        currentCommandList_->CopyTexture(src->GetNativeTexture().get(), dst->GetNativeTexture().get());
+        ResumeRenderPass();
+    } else {
+        currentCommandList_->CopyTexture(src->GetNativeTexture().get(), dst->GetNativeTexture().get());
+    }
+}
+
+std::shared_ptr<RenderTexture> CommandList::GetCurrentRenderTarget() const {
+    if (currentRenderTarget_ == nullptr) return internalScreen_;
+    
+    return currentRenderTarget_;
 }
 
 LLGI::SingleFrameMemoryPool* CommandList::GetMemoryPool() const { return memoryPool_.get(); }

--- a/core/src/Graphics/CommandList.h
+++ b/core/src/Graphics/CommandList.h
@@ -53,6 +53,7 @@ private:
     LLGI::CommandList* currentCommandList_ = nullptr;
     std::shared_ptr<LLGI::SingleFrameMemoryPool> memoryPool_;
     std::shared_ptr<LLGI::CommandListPool> commandListPool_;
+    std::shared_ptr<RenderTexture> currentRenderTarget_;
     std::shared_ptr<LLGI::RenderPass> currentRenderPass_;
     bool isInRenderPass_ = false;
 
@@ -77,6 +78,14 @@ public:
     void EndFrame();
 
     void SetScissor(const RectI& scissor);
+
+    void BeginRenderPass(std::shared_ptr<RenderTexture> target, std::shared_ptr<LLGI::RenderPass> renderPass);
+
+    void EndRenderPass();
+
+    void PauseRenderPass();
+
+    void ResumeRenderPass();
 
     void SetRenderTarget(std::shared_ptr<RenderTexture> target, const RenderPassParameter& renderPassParameter);
 
@@ -112,6 +121,13 @@ public:
             std::shared_ptr<Shader> shader,
             LLGI::ShaderStageType shaderStage,
             std::shared_ptr<MaterialPropertyBlockCollection> matPropBlockCollection);
+
+    /**
+        @brief Call CopyTexture outside of RenderPass
+    */
+    void CopyTexture(std::shared_ptr<RenderTexture> src, std::shared_ptr<RenderTexture> dst);
+
+    std::shared_ptr<RenderTexture> GetCurrentRenderTarget() const;
 
     LLGI::SingleFrameMemoryPool* GetMemoryPool() const;
     LLGI::RenderPass* GetCurrentRenderPass() const;

--- a/core/src/Graphics/Renderer/Renderer.h
+++ b/core/src/Graphics/Renderer/Renderer.h
@@ -6,6 +6,7 @@
 #include "../../Common/Array.h"
 #include "../BatchRenderer.h"
 #include "Rendered.h"
+#include "../RenderTexture.h"
 
 namespace Altseed {
 
@@ -19,12 +20,27 @@ class Window;
 
 class Renderer : public BaseObject {
 private:
+    struct RenderTextureCacheKey {
+        private:
+            Vector2I value_;
+        public:
+            RenderTextureCacheKey(Vector2I value) { value_ = value; }
+            bool operator<(const RenderTextureCacheKey& other) const { return value_.X < other.value_.X && value_.Y < other.value_.Y; }
+    };
+
+    struct RenderTextureCache {
+        int32_t Life = 0;
+        std::shared_ptr<RenderTexture> Stored;
+    };
+
     static std::shared_ptr<Renderer> instance_;
     std::shared_ptr<Window> window_;
     std::shared_ptr<Graphics> graphics_;
     std::shared_ptr<BatchRenderer> batchRenderer_;
     std::shared_ptr<CullingSystem> cullingSystem_;
     std::vector<std::shared_ptr<RenderedCamera>> cameras_;
+
+    std::map<RenderTextureCacheKey, RenderTextureCache> renderTextureCaches_;
 
 public:
     Renderer(std::shared_ptr<Window> window, std::shared_ptr<Graphics> graphics, std::shared_ptr<CullingSystem> cullingSystem);
@@ -36,6 +52,8 @@ public:
             std::shared_ptr<Window> window, std::shared_ptr<Graphics> graphics, std::shared_ptr<CullingSystem> cullingSystem);
 
     static void Terminate();
+
+    void DoEvent();
 
     void DrawPolygon(const BatchVertex* vb, const int32_t* ib, int32_t vbCount, int32_t ibCount, const std::shared_ptr<Texture2D>& texture);
 
@@ -55,6 +73,8 @@ public:
 #undef DrawText
 #endif
     void DrawText(std::shared_ptr<RenderedText> text);
+
+    void RenderPostEffect(std::shared_ptr<Material> material);
 
     void Render();
 

--- a/core/test/Graphics.cpp
+++ b/core/test/Graphics.cpp
@@ -21,6 +21,7 @@
 #include "Graphics/Renderer/RenderedText.h"
 #include "Graphics/Renderer/Renderer.h"
 #include "Graphics/Shader.h"
+#include "Graphics/Material.h"
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
 #include "Logger/Log.h"
 #include "Math/Matrix44F.h"
@@ -649,6 +650,133 @@ TEST(Graphics, CullingTooManySprite) {
         Altseed::Renderer::GetInstance()->Render();
 
         EXPECT_TRUE(instance->EndFrame());
+    }
+
+    Altseed::Core::Terminate();
+}
+
+const char* PostEffectCode = R"(
+Texture2D mainTex : register(t0);
+SamplerState mainSamp : register(s0);
+cbuffer Consts : register(b1)
+{
+    float4 time;
+};
+struct PS_INPUT
+{
+    float4  Position : SV_POSITION;
+    float4  Color    : COLOR0;
+    float2  UV1 : UV0;
+    float2  UV2 : UV1;
+};
+float4 main(PS_INPUT input) : SV_TARGET 
+{ 
+    if (input.UV1.x > 0.5) {
+        return float4(input.UV1, 1.0, 1.0);
+    }
+
+    float x = frac(input.UV1.x + time.x * 0.5 - floor(input.UV1.y * 10) * 0.1);
+
+    float4 tex = mainTex.Sample(mainSamp, float2(x, input.UV1.y));
+    
+    return float4(tex.xyz, 1.0);
+}
+)";
+
+TEST(Graphics, PostEffect) {
+    EXPECT_TRUE(Altseed::Core::Initialize(u"SpriteTexture", 1280, 720, Altseed::Configuration::Create()));
+
+    auto instance = Altseed::Graphics::GetInstance();
+
+    auto t1 = Altseed::Texture2D::Load(u"TestData/IO/AltseedPink.png");
+    EXPECT_TRUE(t1 != nullptr);
+
+    auto s1 = Altseed::RenderedSprite::Create();
+    s1->SetTexture(t1);
+    s1->SetSrc(Altseed::RectF(0, 0, 400, 400));
+
+    auto ps = Altseed::Shader::Create(u"posteffect", Altseed::utf8_to_utf16(PostEffectCode).c_str(), Altseed::ShaderStageType::Pixel);
+    auto material = Altseed::MakeAsdShared<Altseed::Material>();
+    material->SetShader(ps);
+
+    int count = 0;
+    while (count++ < 180 && instance->DoEvents()) {
+        Altseed::CullingSystem::GetInstance()->UpdateAABB();
+        Altseed::CullingSystem::GetInstance()->Cull(Altseed::RectF(Altseed::Vector2F(), Altseed::Window::GetInstance()->GetSize().To2F()));
+
+        material->SetVector4F(u"time", Altseed::Vector4F(count / 180.0, 0.0, 0.0, 0.0));
+        EXPECT_TRUE(instance->BeginFrame());
+
+        Altseed::Renderer::GetInstance()->DrawSprite(s1);
+        Altseed::Renderer::GetInstance()->RenderPostEffect(material);
+        Altseed::Renderer::GetInstance()->Render();
+
+        EXPECT_TRUE(instance->EndFrame());
+    }
+
+    Altseed::Core::Terminate();
+}
+
+TEST(Graphics, PostEffectRenderTexture) {
+    auto config = Altseed::Configuration::Create();
+    config->SetFileLoggingEnabled(true);
+    config->SetConsoleLoggingEnabled(true);
+    config->SetLogFileName(u"RenderTexture.txt");
+    EXPECT_TRUE(Altseed::Core::Initialize(u"RenderTexture", 1280, 720, config));
+    Altseed::Log::GetInstance()->SetLevel(Altseed::LogCategory::Graphics, Altseed::LogLevel::Trace);
+
+    int count = 0;
+
+    auto instance = Altseed::Graphics::GetInstance();
+
+    auto t1 = Altseed::Texture2D::Load(u"TestData/IO/AltseedPink.png");
+    EXPECT_TRUE(t1 != nullptr);
+    t1->SetInstanceName("t1");
+
+    auto rt = Altseed::RenderTexture::Create(Altseed::Vector2I(200, 200));
+    rt->SetInstanceName("rt");
+
+    auto s1 = Altseed::RenderedSprite::Create();
+    s1->SetTexture(t1);
+    s1->SetSrc(Altseed::RectF(0, 0, 200, 200));
+
+    auto s2 = Altseed::RenderedSprite::Create();
+    {
+        auto transform = Altseed::Matrix44F().SetTranslation(200, 200, 0);
+        s2->SetTransform(transform);
+        s2->SetTexture(rt);
+        s2->SetSrc(Altseed::RectF(0, 0, 200, 200));
+    }
+    auto camera = Altseed::RenderedCamera::Create();
+    { camera->SetTargetTexture(rt); }
+
+    auto camera2 = Altseed::RenderedCamera::Create();
+
+    auto ps = Altseed::Shader::Create(u"posteffect", Altseed::utf8_to_utf16(PostEffectCode).c_str(), Altseed::ShaderStageType::Pixel);
+    auto material = Altseed::MakeAsdShared<Altseed::Material>();
+    material->SetShader(ps);
+
+    while (count++ < 180 && instance->DoEvents()) {
+        Altseed::CullingSystem::GetInstance()->UpdateAABB();
+        Altseed::CullingSystem::GetInstance()->Cull(Altseed::RectF(Altseed::Vector2F(), Altseed::Window::GetInstance()->GetSize().To2F()));
+
+        material->SetVector4F(u"time", Altseed::Vector4F(count / 180.0, 0.0, 0.0, 0.0));
+        if (count == 2) Altseed::FrameDebugger::GetInstance()->Start();
+
+        EXPECT_TRUE(instance->BeginFrame());
+
+        auto r = Altseed::Renderer::GetInstance();
+        r->SetCamera(camera);
+        r->DrawSprite(s1);
+        r->RenderPostEffect(material);
+        r->Render();
+
+        r->SetCamera(camera2);
+        r->DrawSprite(s2);
+        r->Render();
+
+        EXPECT_TRUE(instance->EndFrame());
+        if (count == 2) Altseed::FrameDebugger::GetInstance()->DumpToLog();
     }
 
     Altseed::Core::Terminate();


### PR DESCRIPTION
とりあえず` size` だけの `cache` で
```
Altseed::Renderer::GetInstance()->DrawSprite(s1);
Altseed::Renderer::GetInstance()->RenderPostEffect(material);
```
と `DrawSprite` と同じ感覚で書けば `PostEffect` がかかる様にしたけど、今は `Material` を直接描画しているため、 `Culling` との兼ね合いをどうすればいいんだろうとなっています。