### PR TITLE
Joystick refactoring with glfw

### DIFF
--- a/core/src/AutoGeneratedCoreWrapper.cpp
+++ b/core/src/AutoGeneratedCoreWrapper.cpp
@@ -5,76 +5,89 @@
 //   このファイルへの変更は消失することがあります。
 //
 //   THIS FILE IS AUTO GENERATED.
-//   YOUR COMMITMENT ON THIS FILE WILL BE WIPED.
+//   YOUR COMMITMENT ON THIS FILE WILL BE WIPED. 
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-#include <stdint.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
-#include <Windows.h>
+  #include <Windows.h>
 #endif
 
 #ifndef CBGEXPORT
 #if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
-#define CBGEXPORT __declspec(dllexport)
+  #define CBGEXPORT __declspec(dllexport)
 #else
-#define CBGEXPORT
+  #define CBGEXPORT
 #endif
 #endif
 
 #ifndef CBGSTDCALL
 #if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
-#define CBGSTDCALL __stdcall
+  #define CBGSTDCALL __stdcall
 #else
-#define CBGSTDCALL
+  #define CBGSTDCALL
 #endif
 #endif
 
-#include "BaseObject.h"
-#include "Common/Array.h"
-#include "Common/Resource.h"
-#include "Common/ResourceContainer.h"
-#include "Common/Resources.h"
+
 #include "Core.h"
-#include "Graphics/BuiltinShader.h"
-#include "Graphics/CommandList.h"
-#include "Graphics/Font.h"
-#include "Graphics/Graphics.h"
-#include "Graphics/ImageFont.h"
-#include "Graphics/RenderTexture.h"
-#include "Graphics/Renderer/RenderedCamera.h"
-#include "Graphics/Renderer/RenderedPolygon.h"
-#include "Graphics/Renderer/RenderedSprite.h"
-#include "Graphics/Renderer/RenderedText.h"
-#include "Graphics/Renderer/Renderer.h"
-#include "Graphics/Texture2D.h"
-#include "IO/BaseFileReader.h"
-#include "IO/File.h"
-#include "IO/FileRoot.h"
-#include "IO/PackFile.h"
-#include "IO/PackFileReader.h"
-#include "IO/StaticFile.h"
-#include "IO/StreamFile.h"
+#include "BaseObject.h"
+
+#include "Common/Array.h"
+#include "Common/ResourceContainer.h"
+#include "Common/Resource.h"
+#include "Common/Resources.h"
+
+#include "Window/Window.h"
+
 #include "Input/ButtonState.h"
 #include "Input/Joystick.h"
 #include "Input/Keyboard.h"
 #include "Input/Mouse.h"
-#include "Logger/Log.h"
-#include "Physics/Collider/CircleCollider.h"
+
+#include "Graphics/Graphics.h"
+#include "Graphics/CommandList.h"
+#include "Graphics/Texture2D.h"
+#include "Graphics/RenderTexture.h"
+#include "Graphics/Font.h"
+#include "Graphics/ImageFont.h"
+#include "Graphics/Renderer/Renderer.h"
+#include "Graphics/Renderer/RenderedSprite.h"
+#include "Graphics/Renderer/RenderedText.h"
+#include "Graphics/Renderer/RenderedPolygon.h"
+#include "Graphics/Renderer/RenderedCamera.h"
+#include "Graphics/BuiltinShader.h"
+
+#include "Tool/Tool.h"
+
+#include "IO/File.h"
+#include "IO/PackFile.h"
+#include "IO/StaticFile.h"
+#include "IO/StreamFile.h"
+#include "IO/FileRoot.h"
+#include "IO/BaseFileReader.h"
+#include "IO/PackFileReader.h"
+
 #include "Physics/Collider/Collider.h"
-#include "Physics/Collider/PolygonCollider.h"
+#include "Physics/Collider/CircleCollider.h"
 #include "Physics/Collider/RectangleCollider.h"
+#include "Physics/Collider/PolygonCollider.h"
+
 #include "Sound/Sound.h"
 #include "Sound/SoundMixer.h"
-#include "Tool/Tool.h"
-#include "Window/Window.h"
 
+#include "Logger/Log.h"
+
+    
 extern "C" {
 
-CBGEXPORT void* CBGSTDCALL cbg_Configuration_Constructor_0() { return new Altseed::Configuration(); }
+CBGEXPORT void* CBGSTDCALL cbg_Configuration_Constructor_0() {
+    return new Altseed::Configuration();
+}
 
 CBGEXPORT bool CBGSTDCALL cbg_Configuration_GetIsFullscreen(void* cbg_self) {
     auto cbg_self_ = (Altseed::Configuration*)(cbg_self);
@@ -212,8 +225,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Core_Initialize(const char16_t* title, int32_t wid
     const char16_t* cbg_arg0 = title;
     int32_t cbg_arg1 = width;
     int32_t cbg_arg2 = height;
-    std::shared_ptr<Altseed::Configuration> cbg_arg3 =
-            Altseed::CreateAndAddSharedPtr<Altseed::Configuration>((Altseed::Configuration*)config);
+    std::shared_ptr<Altseed::Configuration> cbg_arg3 = Altseed::CreateAndAddSharedPtr<Altseed::Configuration>((Altseed::Configuration*)config);
     bool cbg_ret = Altseed::Core::Initialize(cbg_arg0, cbg_arg1, cbg_arg2, cbg_arg3);
     return cbg_ret;
 }
@@ -225,7 +237,9 @@ CBGEXPORT bool CBGSTDCALL cbg_Core_DoEvent(void* cbg_self) {
     return cbg_ret;
 }
 
-CBGEXPORT void CBGSTDCALL cbg_Core_Terminate() { Altseed::Core::Terminate(); }
+CBGEXPORT void CBGSTDCALL cbg_Core_Terminate() {
+    Altseed::Core::Terminate();
+}
 
 CBGEXPORT void* CBGSTDCALL cbg_Core_GetInstance() {
     std::shared_ptr<Altseed::Core> cbg_ret = Altseed::Core::GetInstance();
@@ -754,6 +768,68 @@ CBGEXPORT void CBGSTDCALL cbg_Mouse_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
+CBGEXPORT const char16_t* CBGSTDCALL cbg_JoystickInfo_GetName(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    const char16_t* cbg_ret = cbg_self_->GetName();
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetButtonCount(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetButtonCount();
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetAxisCount(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetAxisCount();
+    return cbg_ret;
+}
+
+CBGEXPORT const char16_t* CBGSTDCALL cbg_JoystickInfo_GetGUID(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    const char16_t* cbg_ret = cbg_self_->GetGUID();
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetBustype(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetBustype();
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetVendor(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetVendor();
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetProduct(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetProduct();
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetVersion(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetVersion();
+    return cbg_ret;
+}
+
+CBGEXPORT void CBGSTDCALL cbg_JoystickInfo_Release(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    cbg_self_->Release();
+}
+
 CBGEXPORT void* CBGSTDCALL cbg_Joystick_GetInstance() {
     std::shared_ptr<Altseed::Joystick> cbg_ret = Altseed::Joystick::GetInstance();
     return (void*)Altseed::AddAndGetSharedPtr<Altseed::Joystick>(cbg_ret);
@@ -767,10 +843,12 @@ CBGEXPORT bool CBGSTDCALL cbg_Joystick_IsPresent(void* cbg_self, int32_t joystic
     return cbg_ret;
 }
 
-CBGEXPORT void CBGSTDCALL cbg_Joystick_RefreshConnectedState(void* cbg_self) {
+CBGEXPORT void* CBGSTDCALL cbg_Joystick_GetJoystickInfo(void* cbg_self, int32_t joystickIndex) {
     auto cbg_self_ = (Altseed::Joystick*)(cbg_self);
 
-    cbg_self_->RefreshConnectedState();
+    int32_t cbg_arg0 = joystickIndex;
+    std::shared_ptr<Altseed::JoystickInfo> cbg_ret = cbg_self_->GetJoystickInfo(cbg_arg0);
+    return (void*)Altseed::AddAndGetSharedPtr<Altseed::JoystickInfo>(cbg_ret);
 }
 
 CBGEXPORT int32_t CBGSTDCALL cbg_Joystick_GetButtonStateByIndex(void* cbg_self, int32_t joystickIndex, int32_t buttonIndex) {
@@ -791,14 +869,6 @@ CBGEXPORT int32_t CBGSTDCALL cbg_Joystick_GetButtonStateByType(void* cbg_self, i
     return (int32_t)cbg_ret;
 }
 
-CBGEXPORT int32_t CBGSTDCALL cbg_Joystick_GetJoystickType(void* cbg_self, int32_t index) {
-    auto cbg_self_ = (Altseed::Joystick*)(cbg_self);
-
-    int32_t cbg_arg0 = index;
-    Altseed::JoystickType cbg_ret = cbg_self_->GetJoystickType(cbg_arg0);
-    return (int32_t)cbg_ret;
-}
-
 CBGEXPORT float CBGSTDCALL cbg_Joystick_GetAxisStateByIndex(void* cbg_self, int32_t joystickIndex, int32_t axisIndex) {
     auto cbg_self_ = (Altseed::Joystick*)(cbg_self);
 
@@ -815,23 +885,6 @@ CBGEXPORT float CBGSTDCALL cbg_Joystick_GetAxisStateByType(void* cbg_self, int32
     Altseed::JoystickAxisType cbg_arg1 = (Altseed::JoystickAxisType)type;
     float cbg_ret = cbg_self_->GetAxisStateByType(cbg_arg0, cbg_arg1);
     return cbg_ret;
-}
-
-CBGEXPORT const char16_t* CBGSTDCALL cbg_Joystick_GetJoystickName(void* cbg_self, int32_t index) {
-    auto cbg_self_ = (Altseed::Joystick*)(cbg_self);
-
-    int32_t cbg_arg0 = index;
-    const char16_t* cbg_ret = cbg_self_->GetJoystickName(cbg_arg0);
-    return cbg_ret;
-}
-
-CBGEXPORT void CBGSTDCALL cbg_Joystick_Vibrate(void* cbg_self, int32_t index, float frequency, float amplitude) {
-    auto cbg_self_ = (Altseed::Joystick*)(cbg_self);
-
-    int32_t cbg_arg0 = index;
-    float cbg_arg1 = frequency;
-    float cbg_arg2 = amplitude;
-    cbg_self_->Vibrate(cbg_arg0, cbg_arg1, cbg_arg2);
 }
 
 CBGEXPORT void CBGSTDCALL cbg_Joystick_Release(void* cbg_self) {
@@ -953,7 +1006,9 @@ CBGEXPORT void CBGSTDCALL cbg_RenderTexture_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
-CBGEXPORT void* CBGSTDCALL cbg_Material_Constructor_0() { return new Altseed::Material(); }
+CBGEXPORT void* CBGSTDCALL cbg_Material_Constructor_0() {
+    return new Altseed::Material();
+}
 
 CBGEXPORT Altseed::Vector4F_C CBGSTDCALL cbg_Material_GetVector4F(void* cbg_self, const char16_t* key) {
     auto cbg_self_ = (Altseed::Material*)(cbg_self);
@@ -1046,8 +1101,7 @@ CBGEXPORT void* CBGSTDCALL cbg_Renderer_GetInstance() {
 CBGEXPORT void CBGSTDCALL cbg_Renderer_DrawSprite(void* cbg_self, void* sprite) {
     auto cbg_self_ = (Altseed::Renderer*)(cbg_self);
 
-    std::shared_ptr<Altseed::RenderedSprite> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::RenderedSprite>((Altseed::RenderedSprite*)sprite);
+    std::shared_ptr<Altseed::RenderedSprite> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::RenderedSprite>((Altseed::RenderedSprite*)sprite);
     cbg_self_->DrawSprite(cbg_arg0);
 }
 
@@ -1061,8 +1115,7 @@ CBGEXPORT void CBGSTDCALL cbg_Renderer_DrawText(void* cbg_self, void* text) {
 CBGEXPORT void CBGSTDCALL cbg_Renderer_DrawPolygon(void* cbg_self, void* polygon) {
     auto cbg_self_ = (Altseed::Renderer*)(cbg_self);
 
-    std::shared_ptr<Altseed::RenderedPolygon> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::RenderedPolygon>((Altseed::RenderedPolygon*)polygon);
+    std::shared_ptr<Altseed::RenderedPolygon> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::RenderedPolygon>((Altseed::RenderedPolygon*)polygon);
     cbg_self_->DrawPolygon(cbg_arg0);
 }
 
@@ -1075,8 +1128,7 @@ CBGEXPORT void CBGSTDCALL cbg_Renderer_Render(void* cbg_self) {
 CBGEXPORT void CBGSTDCALL cbg_Renderer_SetCamera(void* cbg_self, void* camera) {
     auto cbg_self_ = (Altseed::Renderer*)(cbg_self);
 
-    std::shared_ptr<Altseed::RenderedCamera> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::RenderedCamera>((Altseed::RenderedCamera*)camera);
+    std::shared_ptr<Altseed::RenderedCamera> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::RenderedCamera>((Altseed::RenderedCamera*)camera);
     cbg_self_->SetCamera(cbg_arg0);
 }
 
@@ -1099,23 +1151,19 @@ CBGEXPORT void* CBGSTDCALL cbg_CommandList_GetScreenTexture(void* cbg_self) {
     return (void*)Altseed::AddAndGetSharedPtr<Altseed::RenderTexture>(cbg_ret);
 }
 
-CBGEXPORT void CBGSTDCALL
-cbg_CommandList_SetRenderTarget(void* cbg_self, void* target, Altseed::RenderPassParameter_C renderPassParameter) {
+CBGEXPORT void CBGSTDCALL cbg_CommandList_SetRenderTarget(void* cbg_self, void* target, Altseed::RenderPassParameter_C renderPassParameter) {
     auto cbg_self_ = (Altseed::CommandList*)(cbg_self);
 
-    std::shared_ptr<Altseed::RenderTexture> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::RenderTexture>((Altseed::RenderTexture*)target);
+    std::shared_ptr<Altseed::RenderTexture> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::RenderTexture>((Altseed::RenderTexture*)target);
     Altseed::RenderPassParameter_C cbg_arg1 = renderPassParameter;
     cbg_self_->SetRenderTarget(cbg_arg0, cbg_arg1);
 }
 
-CBGEXPORT void CBGSTDCALL
-cbg_CommandList_RenderToRenderTexture(void* cbg_self, void* material, void* target, Altseed::RenderPassParameter_C renderPassparameter) {
+CBGEXPORT void CBGSTDCALL cbg_CommandList_RenderToRenderTexture(void* cbg_self, void* material, void* target, Altseed::RenderPassParameter_C renderPassparameter) {
     auto cbg_self_ = (Altseed::CommandList*)(cbg_self);
 
     std::shared_ptr<Altseed::Material> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::Material>((Altseed::Material*)material);
-    std::shared_ptr<Altseed::RenderTexture> cbg_arg1 =
-            Altseed::CreateAndAddSharedPtr<Altseed::RenderTexture>((Altseed::RenderTexture*)target);
+    std::shared_ptr<Altseed::RenderTexture> cbg_arg1 = Altseed::CreateAndAddSharedPtr<Altseed::RenderTexture>((Altseed::RenderTexture*)target);
     Altseed::RenderPassParameter_C cbg_arg2 = renderPassparameter;
     cbg_self_->RenderToRenderTexture(cbg_arg0, cbg_arg1, cbg_arg2);
 }
@@ -1387,8 +1435,7 @@ CBGEXPORT void* CBGSTDCALL cbg_RenderedPolygon_Create() {
 CBGEXPORT void CBGSTDCALL cbg_RenderedPolygon_CreateVertexesByVector2F(void* cbg_self, void* vertexes) {
     auto cbg_self_ = (Altseed::RenderedPolygon*)(cbg_self);
 
-    std::shared_ptr<Altseed::Vector2FArray> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::Vector2FArray>((Altseed::Vector2FArray*)vertexes);
+    std::shared_ptr<Altseed::Vector2FArray> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::Vector2FArray>((Altseed::Vector2FArray*)vertexes);
     cbg_self_->CreateVertexesByVector2F(cbg_arg0);
 }
 
@@ -1490,8 +1537,7 @@ CBGEXPORT void* CBGSTDCALL cbg_RenderedCamera_GetTargetTexture(void* cbg_self) {
 CBGEXPORT void CBGSTDCALL cbg_RenderedCamera_SetTargetTexture(void* cbg_self, void* value) {
     auto cbg_self_ = (Altseed::RenderedCamera*)(cbg_self);
 
-    std::shared_ptr<Altseed::RenderTexture> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::RenderTexture>((Altseed::RenderTexture*)value);
+    std::shared_ptr<Altseed::RenderTexture> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::RenderTexture>((Altseed::RenderTexture*)value);
     cbg_self_->SetTargetTexture(cbg_arg0);
 }
 
@@ -1674,8 +1720,7 @@ CBGEXPORT void* CBGSTDCALL cbg_Font_LoadStaticFont(const char16_t* path) {
     return (void*)Altseed::AddAndGetSharedPtr<Altseed::Font>(cbg_ret);
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Font_GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* staticFontPath, int32_t size, const char16_t* characters) {
+CBGEXPORT bool CBGSTDCALL cbg_Font_GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* staticFontPath, int32_t size, const char16_t* characters) {
     const char16_t* cbg_arg0 = dynamicFontPath;
     const char16_t* cbg_arg1 = staticFontPath;
     int32_t cbg_arg2 = size;
@@ -1959,7 +2004,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_Button(void* cbg_self, const char16_t* label,
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_CheckBox(void* cbg_self, const char16_t* label, bool* v) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_CheckBox(void* cbg_self, const char16_t* label, bool * v) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -1977,7 +2022,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton_2(void* cbg_self, const char16_t* label, int32_t* v, int32_t v_button) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton_2(void* cbg_self, const char16_t* label, int32_t * v, int32_t v_button) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2005,8 +2050,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InvisibleButton(void* cbg_self, const char16_
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t* current, const char16_t* items, int32_t popupMaxHeightInItems) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t * current, const char16_t* items, int32_t popupMaxHeightInItems) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2017,7 +2061,7 @@ cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t* current, const 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* label, bool* selected, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* label, bool * selected, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2027,8 +2071,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT const char16_t* CBGSTDCALL
-cbg_Tool_InputText(void* cbg_self, const char16_t* label, const char16_t* input, int32_t maxLength, int32_t flags) {
+CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputText(void* cbg_self, const char16_t* label, const char16_t* input, int32_t maxLength, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2039,8 +2082,7 @@ cbg_Tool_InputText(void* cbg_self, const char16_t* label, const char16_t* input,
     return cbg_ret;
 }
 
-CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextWithHint(
-        void* cbg_self, const char16_t* label, const char16_t* hit, const char16_t* input, int32_t maxLength, int32_t flags) {
+CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextWithHint(void* cbg_self, const char16_t* label, const char16_t* hit, const char16_t* input, int32_t maxLength, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2052,8 +2094,7 @@ CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextWithHint(
     return cbg_ret;
 }
 
-CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextMultiline(
-        void* cbg_self, const char16_t* label, const char16_t* input, int32_t maxLength, Altseed::Vector2F_C size, int32_t flags) {
+CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextMultiline(void* cbg_self, const char16_t* label, const char16_t* input, int32_t maxLength, Altseed::Vector2F_C size, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2065,7 +2106,7 @@ CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextMultiline(
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt(void* cbg_self, const char16_t* label, int32_t* value) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt(void* cbg_self, const char16_t* label, int32_t * value) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2101,7 +2142,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt4(void* cbg_self, const char16_t* lab
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat(void* cbg_self, const char16_t* label, float* value) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat(void* cbg_self, const char16_t* label, float * value) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2137,8 +2178,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat4(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t* value, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t * value, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2150,8 +2190,7 @@ cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t* value, float 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderInt2(void* cbg_self, const char16_t* label, void* array, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt2(void* cbg_self, const char16_t* label, void* array, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2163,8 +2202,7 @@ cbg_Tool_SliderInt2(void* cbg_self, const char16_t* label, void* array, float sp
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderInt3(void* cbg_self, const char16_t* label, void* array, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt3(void* cbg_self, const char16_t* label, void* array, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2176,8 +2214,7 @@ cbg_Tool_SliderInt3(void* cbg_self, const char16_t* label, void* array, float sp
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderInt4(void* cbg_self, const char16_t* label, void* array, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt4(void* cbg_self, const char16_t* label, void* array, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2189,8 +2226,7 @@ cbg_Tool_SliderInt4(void* cbg_self, const char16_t* label, void* array, float sp
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float* value, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float * value, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2202,8 +2238,7 @@ cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float* value, float 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderFloat2(void* cbg_self, const char16_t* label, void* array, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat2(void* cbg_self, const char16_t* label, void* array, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2215,8 +2250,7 @@ cbg_Tool_SliderFloat2(void* cbg_self, const char16_t* label, void* array, float 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderFloat3(void* cbg_self, const char16_t* label, void* array, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat3(void* cbg_self, const char16_t* label, void* array, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2228,8 +2262,7 @@ cbg_Tool_SliderFloat3(void* cbg_self, const char16_t* label, void* array, float 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_SliderFloat4(void* cbg_self, const char16_t* label, void* array, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat4(void* cbg_self, const char16_t* label, void* array, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2241,7 +2274,7 @@ cbg_Tool_SliderFloat4(void* cbg_self, const char16_t* label, void* array, float 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* label, float* angle) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* label, float * angle) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2250,8 +2283,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed::Vector2F_C size, int32_t* value, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed::Vector2F_C size, int32_t * value, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2263,8 +2295,7 @@ cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed::Vector2F_C s
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed::Vector2F_C size, float* value, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed::Vector2F_C size, float * value, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2276,8 +2307,7 @@ cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed::Vector2F_C
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t* value, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t * value, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2289,8 +2319,7 @@ cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t* value, float sp
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float* value, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float * value, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2302,8 +2331,7 @@ cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float* value, float sp
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(
-        void* cbg_self, const char16_t* label, int32_t* currentMin, int32_t* currentMax, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t* label, int32_t * currentMin, int32_t * currentMax, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2316,8 +2344,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(
-        void* cbg_self, const char16_t* label, float* currentMin, float* currentMax, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_t* label, float * currentMin, float * currentMax, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2330,7 +2357,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* label, Altseed::Color_C* color, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* label, Altseed::Color_C * color, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2340,7 +2367,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit4(void* cbg_self, const char16_t* label, Altseed::Color_C* color, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit4(void* cbg_self, const char16_t* label, Altseed::Color_C * color, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3084,14 +3111,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SmallButton(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT void CBGSTDCALL cbg_Tool_Image(
-        void* cbg_self,
-        void* texture,
-        Altseed::Vector2F_C size,
-        Altseed::Vector2F_C uv0,
-        Altseed::Vector2F_C uv1,
-        Altseed::Color_C tintColor,
-        Altseed::Color_C borderColor) {
+CBGEXPORT void CBGSTDCALL cbg_Tool_Image(void* cbg_self, void* texture, Altseed::Vector2F_C size, Altseed::Vector2F_C uv0, Altseed::Vector2F_C uv1, Altseed::Color_C tintColor, Altseed::Color_C borderColor) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     std::shared_ptr<Altseed::TextureBase> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::TextureBase>((Altseed::TextureBase*)texture);
@@ -3103,15 +3123,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_Image(
     cbg_self_->Image(cbg_arg0, cbg_arg1, cbg_arg2, cbg_arg3, cbg_arg4, cbg_arg5);
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ImageButton(
-        void* cbg_self,
-        void* texture,
-        Altseed::Vector2F_C size,
-        Altseed::Vector2F_C uv0,
-        Altseed::Vector2F_C uv1,
-        int32_t framePadding,
-        Altseed::Color_C tintColor,
-        Altseed::Color_C borderColor) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ImageButton(void* cbg_self, void* texture, Altseed::Vector2F_C size, Altseed::Vector2F_C uv0, Altseed::Vector2F_C uv1, int32_t framePadding, Altseed::Color_C tintColor, Altseed::Color_C borderColor) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     std::shared_ptr<Altseed::TextureBase> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::TextureBase>((Altseed::TextureBase*)texture);
@@ -3155,8 +3167,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_EndCombo(void* cbg_self) {
     cbg_self_->EndCombo();
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t* current_item, const char16_t* items, int32_t popupMaxHeightInItems) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t * current_item, const char16_t* items, int32_t popupMaxHeightInItems) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3167,8 +3178,7 @@ cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t* current_item, con
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_Tool_ColorButton(void* cbg_self, const char16_t* descId, Altseed::Color_C* col, int32_t flags, Altseed::Vector2F_C size) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorButton(void* cbg_self, const char16_t* descId, Altseed::Color_C * col, int32_t flags, Altseed::Vector2F_C size) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = descId;
@@ -3208,17 +3218,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_ListBoxFooter(void* cbg_self) {
     cbg_self_->ListBoxFooter();
 }
 
-CBGEXPORT void CBGSTDCALL cbg_Tool_PlotLines(
-        void* cbg_self,
-        const char16_t* label,
-        void* values,
-        int32_t valuesCount,
-        int32_t valuesOffset,
-        const char16_t* overlayText,
-        float scaleMin,
-        float scaleMax,
-        Altseed::Vector2F_C graphSize,
-        int32_t stride) {
+CBGEXPORT void CBGSTDCALL cbg_Tool_PlotLines(void* cbg_self, const char16_t* label, void* values, int32_t valuesCount, int32_t valuesOffset, const char16_t* overlayText, float scaleMin, float scaleMax, Altseed::Vector2F_C graphSize, int32_t stride) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3233,17 +3233,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_PlotLines(
     cbg_self_->PlotLines(cbg_arg0, cbg_arg1, cbg_arg2, cbg_arg3, cbg_arg4, cbg_arg5, cbg_arg6, cbg_arg7, cbg_arg8);
 }
 
-CBGEXPORT void CBGSTDCALL cbg_Tool_PlotHistogram(
-        void* cbg_self,
-        const char16_t* label,
-        void* values,
-        int32_t valuesCount,
-        int32_t valuesOffset,
-        const char16_t* overlayText,
-        float scaleMin,
-        float scaleMax,
-        Altseed::Vector2F_C graphSize,
-        int32_t stride) {
+CBGEXPORT void CBGSTDCALL cbg_Tool_PlotHistogram(void* cbg_self, const char16_t* label, void* values, int32_t valuesCount, int32_t valuesOffset, const char16_t* overlayText, float scaleMin, float scaleMax, Altseed::Vector2F_C graphSize, int32_t stride) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3324,7 +3314,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupContextVoid(void* cbg_self, const c
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupModalEx(void* cbg_self, const char16_t* name, bool* isOpen, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupModalEx(void* cbg_self, const char16_t* name, bool * isOpen, int32_t flags) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = name;
@@ -3410,8 +3400,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_SetTabItemClosed(void* cbg_self, const char16
     cbg_self_->SetTabItemClosed(cbg_arg0);
 }
 
-CBGEXPORT void CBGSTDCALL
-cbg_Tool_PushClipRect(void* cbg_self, Altseed::Vector2F_C clipRectMin, Altseed::Vector2F_C clipRectMax, bool intersectWithCurrentClipRect) {
+CBGEXPORT void CBGSTDCALL cbg_Tool_PushClipRect(void* cbg_self, Altseed::Vector2F_C clipRectMin, Altseed::Vector2F_C clipRectMax, bool intersectWithCurrentClipRect) {
     auto cbg_self_ = (Altseed::Tool*)(cbg_self);
 
     Altseed::Vector2F_C cbg_arg0 = clipRectMin;
@@ -3819,8 +3808,7 @@ CBGEXPORT bool CBGSTDCALL cbg_File_Pack(void* cbg_self, const char16_t* srcPath,
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL
-cbg_File_PackWithPassword(void* cbg_self, const char16_t* srcPath, const char16_t* dstPath, const char16_t* password) {
+CBGEXPORT bool CBGSTDCALL cbg_File_PackWithPassword(void* cbg_self, const char16_t* srcPath, const char16_t* dstPath, const char16_t* password) {
     auto cbg_self_ = (Altseed::File*)(cbg_self);
 
     const char16_t* cbg_arg0 = srcPath;
@@ -4180,7 +4168,9 @@ CBGEXPORT void CBGSTDCALL cbg_Window_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
-CBGEXPORT void* CBGSTDCALL cbg_Collider_Constructor_0() { return new Altseed::Collider(); }
+CBGEXPORT void* CBGSTDCALL cbg_Collider_Constructor_0() {
+    return new Altseed::Collider();
+}
 
 CBGEXPORT bool CBGSTDCALL cbg_Collider_GetIsCollidedWith(void* cbg_self, void* collider) {
     auto cbg_self_ = (Altseed::Collider*)(cbg_self);
@@ -4224,7 +4214,9 @@ CBGEXPORT void CBGSTDCALL cbg_Collider_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
-CBGEXPORT void* CBGSTDCALL cbg_CircleCollider_Constructor_0() { return new Altseed::CircleCollider(); }
+CBGEXPORT void* CBGSTDCALL cbg_CircleCollider_Constructor_0() {
+    return new Altseed::CircleCollider();
+}
 
 CBGEXPORT float CBGSTDCALL cbg_CircleCollider_GetRadius(void* cbg_self) {
     auto cbg_self_ = (Altseed::CircleCollider*)(cbg_self);
@@ -4246,7 +4238,9 @@ CBGEXPORT void CBGSTDCALL cbg_CircleCollider_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
-CBGEXPORT void* CBGSTDCALL cbg_RectangleCollider_Constructor_0() { return new Altseed::RectangleCollider(); }
+CBGEXPORT void* CBGSTDCALL cbg_RectangleCollider_Constructor_0() {
+    return new Altseed::RectangleCollider();
+}
 
 CBGEXPORT Altseed::Vector2F_C CBGSTDCALL cbg_RectangleCollider_GetSize(void* cbg_self) {
     auto cbg_self_ = (Altseed::RectangleCollider*)(cbg_self);
@@ -4282,7 +4276,9 @@ CBGEXPORT void CBGSTDCALL cbg_RectangleCollider_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
-CBGEXPORT void* CBGSTDCALL cbg_PolygonCollider_Constructor_0() { return new Altseed::PolygonCollider(); }
+CBGEXPORT void* CBGSTDCALL cbg_PolygonCollider_Constructor_0() {
+    return new Altseed::PolygonCollider();
+}
 
 CBGEXPORT void* CBGSTDCALL cbg_PolygonCollider_GetVertexes(void* cbg_self) {
     auto cbg_self_ = (Altseed::PolygonCollider*)(cbg_self);
@@ -4294,8 +4290,7 @@ CBGEXPORT void* CBGSTDCALL cbg_PolygonCollider_GetVertexes(void* cbg_self) {
 CBGEXPORT void CBGSTDCALL cbg_PolygonCollider_SetVertexes(void* cbg_self, void* value) {
     auto cbg_self_ = (Altseed::PolygonCollider*)(cbg_self);
 
-    std::shared_ptr<Altseed::Vector2FArray> cbg_arg0 =
-            Altseed::CreateAndAddSharedPtr<Altseed::Vector2FArray>((Altseed::Vector2FArray*)value);
+    std::shared_ptr<Altseed::Vector2FArray> cbg_arg0 = Altseed::CreateAndAddSharedPtr<Altseed::Vector2FArray>((Altseed::Vector2FArray*)value);
     cbg_self_->SetVertexes(cbg_arg0);
 }
 
@@ -4304,4 +4299,7 @@ CBGEXPORT void CBGSTDCALL cbg_PolygonCollider_Release(void* cbg_self) {
 
     cbg_self_->Release();
 }
+
+
 }
+

--- a/core/src/AutoGeneratedCoreWrapper.cpp
+++ b/core/src/AutoGeneratedCoreWrapper.cpp
@@ -768,6 +768,14 @@ CBGEXPORT void CBGSTDCALL cbg_Mouse_Release(void* cbg_self) {
     cbg_self_->Release();
 }
 
+CBGEXPORT bool CBGSTDCALL cbg_JoystickInfo_IsJoystickType(void* cbg_self, int32_t type) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    Altseed::JoystickType cbg_arg0 = (Altseed::JoystickType)type;
+    bool cbg_ret = cbg_self_->IsJoystickType(cbg_arg0);
+    return cbg_ret;
+}
+
 CBGEXPORT const char16_t* CBGSTDCALL cbg_JoystickInfo_GetName(void* cbg_self) {
     auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
 
@@ -821,6 +829,20 @@ CBGEXPORT int32_t CBGSTDCALL cbg_JoystickInfo_GetVersion(void* cbg_self) {
     auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
 
     int32_t cbg_ret = cbg_self_->GetVersion();
+    return cbg_ret;
+}
+
+CBGEXPORT bool CBGSTDCALL cbg_JoystickInfo_GetIsAvailableButtonMapping(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    bool cbg_ret = cbg_self_->GetIsAvailableButtonMapping();
+    return cbg_ret;
+}
+
+CBGEXPORT bool CBGSTDCALL cbg_JoystickInfo_GetIsAvailableAxisMapping(void* cbg_self) {
+    auto cbg_self_ = (Altseed::JoystickInfo*)(cbg_self);
+
+    bool cbg_ret = cbg_self_->GetIsAvailableAxisMapping();
     return cbg_ret;
 }
 
@@ -884,6 +906,13 @@ CBGEXPORT float CBGSTDCALL cbg_Joystick_GetAxisStateByType(void* cbg_self, int32
     int32_t cbg_arg0 = joystickIndex;
     Altseed::JoystickAxisType cbg_arg1 = (Altseed::JoystickAxisType)type;
     float cbg_ret = cbg_self_->GetAxisStateByType(cbg_arg0, cbg_arg1);
+    return cbg_ret;
+}
+
+CBGEXPORT int32_t CBGSTDCALL cbg_Joystick_GetConnectedJoystickCount(void* cbg_self) {
+    auto cbg_self_ = (Altseed::Joystick*)(cbg_self);
+
+    int32_t cbg_ret = cbg_self_->GetConnectedJoystickCount();
     return cbg_ret;
 }
 

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -87,6 +87,7 @@ set(core_files
     Input/ButtonState.h
     Input/Cursor.h
     Input/Cursor.cpp
+    Input/JoystickMapping.h
     Input/Joystick.h
     Input/Joystick.cpp
     Input/Keyboard.h

--- a/core/src/Core.cpp
+++ b/core/src/Core.cpp
@@ -126,8 +126,6 @@ bool Core::Initialize(const char16_t* title, int32_t width, int32_t height, std:
 
     Core::instance->fps_ = std::make_unique<FPS>();
 
-    Altseed::Joystick::GetInstance()->RefreshConnectedState();
-
     return Core::instance != nullptr;
 }
 

--- a/core/src/Input/Joystick.cpp
+++ b/core/src/Input/Joystick.cpp
@@ -94,7 +94,7 @@ void Joystick::RefreshInputState() {
 
         if (joystickInfo_[jind] == nullptr) {
             auto name = glfwGetJoystickName(jind);
-            auto guid = utf8_to_utf16(std::string(glfwGetJoystickGUID(jind)));
+            auto guid = glfwGetJoystickGUID(jind);
             joystickInfo_[jind] = MakeAsdShared<JoystickInfo>(utf8_to_utf16(std::string(name)), buttonsCount, axesCount, guid);
         }
 
@@ -111,13 +111,13 @@ bool Joystick::IsPresent(int32_t joystickIndex) const {
     return (0 <= joystickIndex) && (joystickIndex < MAX_JOYSTICKS_NUM) && joystickInfo_[joystickIndex] != nullptr;
 }
 
-std::shared_ptr<JoystickInfo> Joystick::GetJoystickInfo(int32_t index) const {
-    if (index < 0 || MAX_JOYSTICKS_NUM <= index) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetJoystickInfo: Joystick index '{0}' is out of range.", index);
+std::shared_ptr<JoystickInfo> Joystick::GetJoystickInfo(int32_t joystickIndex) const {
+    if (joystickIndex < 0 || MAX_JOYSTICKS_NUM <= joystickIndex) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetJoystickInfo: joystickIndex '{0}' is out of range.", joystickIndex);
         return nullptr;
     }
 
-    return joystickInfo_[index];
+    return joystickInfo_[joystickIndex];
 }
 
 ButtonState Joystick::GetButtonStateByIndex(int32_t joystickIndex, int32_t buttonIndex) const {
@@ -175,5 +175,9 @@ float Joystick::GetAxisStateByType(int32_t joystickIndex, JoystickAxisType type)
     // TODO
     return GetAxisStateByIndex(joystickIndex, -1);
 };
+
+// void Joystick::Vibrate(int32_t joystickIndex, float frequency, float amplitude) {
+//     Log::GetInstance()->Error(LogCategory::Core, u"Joystick::Vibrate is not supported yet");
+// }
 
 }  // namespace Altseed

--- a/core/src/Input/Joystick.cpp
+++ b/core/src/Input/Joystick.cpp
@@ -5,59 +5,51 @@
 #include <cstring>
 
 #include "../Common/Miscs.h"
+#include "../Logger/Log.h"
 
-#define JOYCON_BUTTON_COUNT 15
-
-#define JOYCON_L_PRODUCT_ID 8198
-#define JOYCON_R_PRODUCT_ID 8199
-#define DUALSHOCK4_PRODUCT_ID 0x0
-#define XBOX360_PRODUCT_ID 0x0
-
-#define JOYCON_L
 
 namespace Altseed {
 
+JoystickInfo::JoystickInfo(const std::u16string name, const int32_t buttonCount, const int32_t axisCount, const char* guid)
+    : name_(name), buttonCount_(buttonCount), axisCount_(axisCount)
+{
+    guid_ = utf8_to_utf16(std::string(guid));
+    unsigned int bustype1, bustype2;
+    unsigned int vendor1, vendor2;
+    unsigned int product1, product2;
+    unsigned int version1, version2;
+    sscanf(guid, "%02x%02x0000%02x%02x0000%02x%02x0000%02x%02x0000", &bustype1, &bustype2, &vendor1, &vendor2, &product1, &product2, &version1, &version2);
+    bustype_ = (bustype2 << 8) | bustype1;
+    vendor_ = (vendor2 << 8) | vendor1;
+    product_ = (product2 << 8) | product1;
+    version_ = (version2 << 8) | version1;
+}
+
 std::shared_ptr<Joystick> Joystick::instance_ = nullptr;
 
-bool Joystick::Initialize() {
-    if (instance_ == nullptr) {
-        instance_ = MakeAsdShared<Joystick>();
-        instance_->types_.fill(JoystickType::Other);
-        instance_->globalCount_ = 0;
-    }
-
+Joystick::Joystick() {
+    joystickInfo_.fill(nullptr);
     for (int32_t i = 0; i < MAX_JOYSTICKS_NUM; i++) {
-        instance_->currentHit_[i].fill(false);
-        instance_->preHit_[i].fill(false);
-        //            currentAxis[i].fill(0);
+        currentHit_[i].fill(false);
+        preHit_[i].fill(false);
+        currentAxis_[i].fill(0.0);
     }
+}
+
+bool Joystick::Initialize() {
+    instance_ = MakeAsdShared<Joystick>();
+    instance_->RefreshInputState();
+
     return true;
 };
 
 void Joystick::Terminate() {
-    for (int jind = 0; jind < MAX_JOYSTICKS_NUM; jind++) {
-        if (!instance_->handler_[jind]) return;
-
-        if (instance_->types_[jind] == JoystickType::JoyconL || instance_->types_[jind] == JoystickType::JoyconR) {
-            uint8_t data[0x01];
-            data[0] = 0;
-            instance_->SendSubcommand(instance_->handler_[jind], 0x30, data, 1);
-
-            data[0] = 0x01;
-            instance_->SendSubcommand(instance_->handler_[jind], 0x48, data, 1);
-
-            hid_close(instance_->handler_[jind]);
-        }
-    }
-
     instance_ = nullptr;
 }
 
 std::shared_ptr<Joystick>& Joystick::GetInstance() { return instance_; }
 
-bool Joystick::IsPresent(int32_t joystickIndex) { return (bool)handler_[joystickIndex]; }
-
-std::u16string Joystick::ToU16(const std::wstring& wstr) {
+std::u16string Joystick::ToU16(const std::wstring& wstr) const {
     if (sizeof(wchar_t) == 4) {
         std::u32string u32(wstr.cbegin(), wstr.cend());
 
@@ -77,310 +69,111 @@ std::u16string Joystick::ToU16(const std::wstring& wstr) {
     }
 }
 
-void Joystick::SendSubcommand(hid_device* dev, uint8_t command, uint8_t data[], int len) {
-    std::array<uint8_t, 0x40> buf;
-    buf.fill(0);
-
-    buf[0] = 1;  // 0x10 for rumble only
-    buf[1] = globalCount_;  // Increment by 1 for each packet sent. It loops in 0x0 - 0xF range.
-
-    if (globalCount_ == 0xf0) {
-        globalCount_ = 0x00;
-    } else {
-        globalCount_++;
-    }
-
-    buf[10] = command;
-    memcpy(buf.data() + 11, data, len);
-
-    hid_write(dev, buf.data(), 0x40);
-}
-
-void Joystick::RefreshConnectedState() {
-    // Get HID handler
-    hid_device_info* firstDevice = hid_enumerate(0, 0);
-    auto device = firstDevice;
-    const char* path;
-    int i = 0;
-
-    //    hid_device_info* device = devices;
-    while (device) {
-        path = device->path;
-
-        if (device->product_id == JOYCON_L_PRODUCT_ID || device->product_id == JOYCON_R_PRODUCT_ID ||
-            device->product_id == DUALSHOCK4_PRODUCT_ID || device->product_id == XBOX360_PRODUCT_ID) {
-            hid_device* dev = hid_open(device->vendor_id, device->product_id, device->serial_number);
-            if (!dev) {
-                break;
-            }
-
-            hid_set_nonblocking(dev, 1);
-            handler_[i] = dev;
-
-            if (device->product_string != nullptr) names_[i] = ToU16(std::wstring(device->product_string));
-            types_[i] = (JoystickType)device->product_id;
-
-            if (types_[i] == JoystickType::JoyconL || types_[i] == JoystickType::JoyconR) {
-                // enable vibration for joycon
-                uint8_t data[0x01];
-                data[0] = 0x01;
-                this->SendSubcommand(dev, 0x48, data, 1);
-
-                // send input report mode
-                data[0] = 0x3F;
-                this->SendSubcommand(dev, 0x03, data, 1);
-
-                // send player light
-                data[0] = (i + 1) % 4;
-                this->SendSubcommand(dev, 0x30, data, 1);
-            }
-            i++;
-        }
-        device = device->next;
-    }
-    hid_free_enumeration(firstDevice);
-};
-
-//    NOTE: pushing in stick is handled as button
-void Joystick::HandleJoyconInput(int index, unsigned char* buff, bool is_left) {
-    if (*buff == 0x21) {
-        // buttons
-        int target_index = 3;
-        if (is_left) {
-            target_index = 5;
-        }
-
-        for (int i = 0; i <= 7; i++) {
-            currentHit_[index][i] = buff[target_index] & (1 << i);
-            currentHit_[index][i + 8] = buff[4] & (1 << i);
-        }
-
-    } else if (*buff == 0x3F) {
-        // hundle buttons
-
-        // convert 0x3F input report buttons status format to standard input report button status format.
-        int to_standard_buttons[16] = {0, 2, 3, 1, 5, 4, 14, 15, 8, 9, 11, 10, 12, 13, 6, 7};
-
-        for (int i = 0; i <= 7; i++) {
-            currentHit_[index][to_standard_buttons[i]] = buff[1] & (1 << i);
-            currentHit_[index][to_standard_buttons[i + 8]] = buff[2] & (1 << i);
-        }
-
-        // stick
-        int axis_type_H = (int32_t)JoystickAxisType::RightH;
-        int axis_type_V = (int32_t)JoystickAxisType::RightV;
-        if (is_left) {
-            axis_type_H = (int32_t)JoystickAxisType::LeftH;
-            axis_type_V = (int32_t)JoystickAxisType::LeftV;
-        }
-
-        switch (buff[3]) {
-                //                    Top
-            case 0:
-                currentAxis_[index][axis_type_H] = 0;
-                currentAxis_[index][axis_type_V] = 1;
-                break;
-                //                    Top-right
-            case 1:
-                currentAxis_[index][axis_type_H] = 1;
-                currentAxis_[index][axis_type_V] = 1;
-                break;
-                //                    Right
-            case 2:
-                currentAxis_[index][axis_type_H] = 1;
-                currentAxis_[index][axis_type_V] = 0;
-                break;
-                //                    Bottom-right
-            case 3:
-                currentAxis_[index][axis_type_H] = 1;
-                currentAxis_[index][axis_type_V] = -1;
-                break;
-                //                    Bottom
-            case 4:
-                currentAxis_[index][axis_type_H] = 0;
-                currentAxis_[index][axis_type_V] = -1;
-                break;
-                //                    Bottom-Left
-            case 5:
-                currentAxis_[index][axis_type_H] = -1;
-                currentAxis_[index][axis_type_V] = -1;
-                break;
-                //                    Left
-            case 6:
-                currentAxis_[index][axis_type_H] = -1;
-                currentAxis_[index][axis_type_V] = 0;
-                break;
-                //                    Top-left
-            case 7:
-                currentAxis_[index][axis_type_H] = -1;
-                currentAxis_[index][axis_type_V] = 1;
-                break;
-
-            default:
-                currentAxis_[index][axis_type_H] = 0;
-                currentAxis_[index][axis_type_V] = 0;
-                break;
-        }
-    }
-};
-
 void Joystick::RefreshInputState() {
     preHit_ = currentHit_;
 
     for (int jind = 0; jind < MAX_JOYSTICKS_NUM; jind++) {
-        if (!handler_[jind]) return;
+        auto isPresent = glfwJoystickPresent(jind) == GLFW_TRUE;
 
-        //            read input report
-        uint8_t buff[0x40];
-        memset(buff, 0x40, size_t(0x40));
-        size_t size = 49;
-
-        int ret = hid_read(handler_[jind], buff, size);
-        if (!ret) {
-            return;
+        if (!isPresent) {
+            joystickInfo_[jind] = nullptr;
+            continue;
         }
 
-        if (types_[jind] == JoystickType::JoyconL) {
-            HandleJoyconInput(jind, buff, true);
-        } else if (types_[jind] == JoystickType::JoyconR) {
-            HandleJoyconInput(jind, buff, false);
+        int32_t buttonsCount = 0;
+        auto btns = glfwGetJoystickButtons(jind, &buttonsCount);
+        for (int i = 0; i < buttonsCount; ++i) {
+            currentHit_[jind][i] = (bool)btns[i];
         }
+
+        int32_t axesCount = 0;
+        auto ax = glfwGetJoystickAxes(jind, &axesCount);
+        for (int i = 0; i < axesCount; ++i) {
+            currentAxis_[jind][i] = ax[i];
+        }
+
+        if (joystickInfo_[jind] == nullptr) {
+            auto name = glfwGetJoystickName(jind);
+            auto guid = utf8_to_utf16(std::string(glfwGetJoystickGUID(jind)));
+            joystickInfo_[jind] = MakeAsdShared<JoystickInfo>(utf8_to_utf16(std::string(name)), buttonsCount, axesCount, guid);
+        }
+
+        // auto jtype = GetJoystickType(jind);
+
+        // if (jtype == JoystickType::XBOX360) {
+        //     currentHit[jind][14] = currentAxis_[jind][4] > 0.8;
+        //     currentHit[jind][15] = currentAxis_[jind][5] > 0.8;
+        // }
     }
 };
 
-void Joystick::Vibrate(int32_t joystickIndex, float frequency, float amplitude) {
-    if (types_[joystickIndex] == Altseed::JoystickType::JoyconL || types_[joystickIndex] == Altseed::JoystickType::JoyconR) {
-        uint8_t buf[0x40];
-        memset(buf, 0x0, size_t(0x40));
-        buf[0] = 0x10;
-        buf[1] = 0x01;
+bool Joystick::IsPresent(int32_t joystickIndex) const {
+    return (0 <= joystickIndex) && (joystickIndex < MAX_JOYSTICKS_NUM) && joystickInfo_[joystickIndex] != nullptr;
+}
 
-        float freq = std::clamp(frequency, 40.0f, 1252.0f);
-        float amp = std::clamp(amplitude, 0.0f, 1.0f);
-
-        uint8_t encoded_hex_freq = (uint8_t)round(log2((double)freq / 10.0) * 32.0);
-
-        uint16_t hf = (encoded_hex_freq - 0x60) * 4;
-        uint8_t lf = encoded_hex_freq - 0x40;
-
-        uint8_t encoded_hex_amp = 0;
-        if (amp > 0.23f)
-            encoded_hex_amp = (uint8_t)round(log2f(amp * 8.7f) * 32.f);
-        else if (amp > 0.12f)
-            encoded_hex_amp = (uint8_t)round(log2f(amp * 17.f) * 16.f);
-        else {
-            encoded_hex_amp = 0;
-        }
-        uint16_t hf_amp = encoded_hex_amp * 2;
-        uint8_t lf_amp = encoded_hex_amp / 2 + 64;
-
-        uint8_t byte[0x08];
-
-        byte[0] = hf & 0xFF;
-        byte[1] = hf_amp + ((hf >> 8) & 0xFF);
-
-        byte[2] = lf + ((lf_amp >> 8) & 0xFF);
-        byte[3] = lf_amp & 0xFF;
-
-        for (int i = 4; i <= 7; i++) {
-            byte[i] = byte[i - 4];
-        }
-
-        memcpy(buf + 2, byte, 8);
-        hid_write(handler_[0], buf, sizeof(buf));
+std::shared_ptr<JoystickInfo> Joystick::GetJoystickInfo(int32_t index) const {
+    if (index < 0 || MAX_JOYSTICKS_NUM <= index) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetJoystickInfo: Joystick index '{0}' is out of range.", index);
+        return nullptr;
     }
-};
+
+    return joystickInfo_[index];
+}
 
 ButtonState Joystick::GetButtonStateByIndex(int32_t joystickIndex, int32_t buttonIndex) const {
-    if (buttonIndex < 0) return ButtonState::Free;
-
-    if (currentHit_[joystickIndex][buttonIndex] && preHit_[joystickIndex][buttonIndex])
-        return ButtonState::Hold;
-    else if (!currentHit_[joystickIndex][buttonIndex] && preHit_[joystickIndex][buttonIndex])
-        return ButtonState::Release;
-    else if (currentHit_[joystickIndex][buttonIndex] && !preHit_[joystickIndex][buttonIndex])
-        return ButtonState::Push;
-    else
+    if (!IsPresent(joystickIndex)) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetButtonStateByIndex: Joystick is not present at {0}", joystickIndex);
         return ButtonState::Free;
+    }
+
+    auto buttonCount = joystickInfo_[joystickIndex]->GetButtonCount();
+    if (buttonIndex < 0 || buttonCount <= buttonIndex) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetButtonStateByIndex: 'buttonIndex: {0}' is out of range, ButtonCount is", buttonIndex, buttonCount);
+        return ButtonState::Free;
+    }
+
+    auto current = currentHit_[joystickIndex][buttonIndex];
+    auto pre = preHit_[joystickIndex][buttonIndex];
+
+    if (current && pre) return ButtonState::Hold;
+    if (!current && pre) return ButtonState::Release;
+    if (current && !pre) return ButtonState::Push;
+    return ButtonState::Free;
 };
 
 ButtonState Joystick::GetButtonStateByType(int32_t joystickIndex, JoystickButtonType type) const {
-    auto jtype = GetJoystickType(joystickIndex);
-
-    if (jtype == JoystickType::Other) return ButtonState::Free;
-
-    if (jtype == JoystickType::JoyconL) {
-        std::array<int, (int32_t)JoystickButtonType::Max> maps;
-        maps.fill(-1);
-
-        maps[(int32_t)JoystickButtonType::LeftDown] = 0;
-        maps[(int32_t)JoystickButtonType::LeftUp] = 1;
-        maps[(int32_t)JoystickButtonType::LeftRight] = 2;
-        maps[(int32_t)JoystickButtonType::LeftLeft] = 3;
-
-        maps[(int32_t)JoystickButtonType::R3] = 4;
-        maps[(int32_t)JoystickButtonType::L3] = 5;
-
-        maps[(int32_t)JoystickButtonType::L1] = 6;
-        maps[(int32_t)JoystickButtonType::L2] = 7;
-
-        maps[(int32_t)JoystickButtonType::Select] = 8;
-        maps[(int32_t)JoystickButtonType::Start] = 9;
-        maps[(int32_t)JoystickButtonType::RightPush] = 10;
-        maps[(int32_t)JoystickButtonType::LeftPush] = 11;
-
-        maps[(int32_t)JoystickButtonType::Home] = 12;
-        maps[(int32_t)JoystickButtonType::Capture] = 13;
-
-        return GetButtonStateByIndex(joystickIndex, maps[(int32_t)type]);
-    } else if (jtype == JoystickType::JoyconR) {
-        std::array<int, (int32_t)JoystickButtonType::Max> maps;
-        maps.fill(-1);
-
-        maps[(int32_t)JoystickButtonType::RightDown] = 0;
-        maps[(int32_t)JoystickButtonType::RightUp] = 1;
-        maps[(int32_t)JoystickButtonType::RightRight] = 2;
-        maps[(int32_t)JoystickButtonType::RightLeft] = 3;
-
-        maps[(int32_t)JoystickButtonType::R3] = 4;
-        maps[(int32_t)JoystickButtonType::L3] = 5;
-
-        maps[(int32_t)JoystickButtonType::R1] = 6;
-        maps[(int32_t)JoystickButtonType::R2] = 7;
-
-        maps[(int32_t)JoystickButtonType::Select] = 8;
-        maps[(int32_t)JoystickButtonType::Start] = 9;
-        maps[(int32_t)JoystickButtonType::RightPush] = 10;
-        maps[(int32_t)JoystickButtonType::LeftPush] = 11;
-
-        maps[(int32_t)JoystickButtonType::Home] = 12;
-        maps[(int32_t)JoystickButtonType::Capture] = 13;
-
-        return GetButtonStateByIndex(joystickIndex, maps[(int32_t)type]);
+    if (!IsPresent(joystickIndex)) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetButtonStateByType: Joystick is not present at {0}", joystickIndex);
+        return ButtonState::Free;
     }
 
-    return ButtonState::Hold;
+    // TODO
+    return GetButtonStateByIndex(joystickIndex, -1);
 };
 
 float Joystick::GetAxisStateByIndex(int32_t joystickIndex, int32_t axisIndex) const {
-    if (axisIndex < 0) return 0;
+    if (!IsPresent(joystickIndex)) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetAxisStateByIndex: Joystick is not present at {0}", joystickIndex);
+        return 0.0f;
+    }
+
+    auto axisCount = joystickInfo_[joystickIndex]->GetAxisCount();
+    if (axisIndex < 0 || axisCount <= axisIndex) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetAxisStateByIndex: 'axisIndex: {0}' is out of range, ButtonCount is", axisIndex, axisCount);
+        return 0.0f;
+    }
 
     return currentAxis_[joystickIndex][axisIndex];
 };
 
 float Joystick::GetAxisStateByType(int32_t joystickIndex, JoystickAxisType type) const {
-    auto jtype = GetJoystickType(joystickIndex);
-    if (jtype == JoystickType::Other) return 0;
-
-    if (jtype == JoystickType::JoyconL || jtype == JoystickType::JoyconR) {
-        return GetAxisStateByIndex(joystickIndex, (int32_t)type);
+    if (!IsPresent(joystickIndex)) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetAxisStateByType: Joystick is not present at {0}", joystickIndex);
+        return 0.0f;
     }
 
-    return 0.0f;
+    // TODO
+    return GetAxisStateByIndex(joystickIndex, -1);
 };
-
-JoystickType Joystick::GetJoystickType(int32_t index) const { return types_[index]; };
-
-const char16_t* Joystick::GetJoystickName(int32_t index) const { return names_[index].c_str(); }
 
 }  // namespace Altseed

--- a/core/src/Input/Joystick.cpp
+++ b/core/src/Input/Joystick.cpp
@@ -6,13 +6,11 @@
 
 #include "../Common/Miscs.h"
 #include "../Logger/Log.h"
-
 #include "JoystickMapping.h"
 
 namespace Altseed {
 JoystickInfo::JoystickInfo(const std::u16string name, const int32_t buttonCount, const int32_t axisCount, const char* guid)
-    : name_(name), buttonCount_(buttonCount), axisCount_(axisCount)
-{
+    : name_(name), buttonCount_(buttonCount), axisCount_(axisCount) {
     guid_ = utf8_to_utf16(std::string(guid));
     unsigned int bustype1, bustype2;
     unsigned int vendor1, vendor2;
@@ -109,7 +107,7 @@ void Joystick::RefreshInputState() {
         for (int i = 0; i < axesCount; ++i) {
             currentAxis_[jind][i] = ax[i];
         }
-        
+
         // Joystickが接続されたフレーム
         if (joystickInfo_[jind] == nullptr) {
             auto name = glfwGetJoystickName(jind);

--- a/core/src/Input/Joystick.cpp
+++ b/core/src/Input/Joystick.cpp
@@ -7,9 +7,9 @@
 #include "../Common/Miscs.h"
 #include "../Logger/Log.h"
 
+#include "JoystickMapping.h"
 
 namespace Altseed {
-
 JoystickInfo::JoystickInfo(const std::u16string name, const int32_t buttonCount, const int32_t axisCount, const char* guid)
     : name_(name), buttonCount_(buttonCount), axisCount_(axisCount)
 {
@@ -25,9 +25,18 @@ JoystickInfo::JoystickInfo(const std::u16string name, const int32_t buttonCount,
     version_ = (version2 << 8) | version1;
 }
 
+bool JoystickInfo::GetIsAvailableButtonMapping() const {
+    return ButtonMapping.find(product_) != ButtonMapping.end();
+}
+
+bool JoystickInfo::GetIsAvailableAxisMapping() const {
+    return AxisMapping.find(product_) != AxisMapping.end();
+}
+
 std::shared_ptr<Joystick> Joystick::instance_ = nullptr;
 
-Joystick::Joystick() {
+Joystick::Joystick() : connectedJoystickCount_(0) {
+    // hidapiDevices_.fill(nullptr);
     joystickInfo_.fill(nullptr);
     for (int32_t i = 0; i < MAX_JOYSTICKS_NUM; i++) {
         currentHit_[i].fill(false);
@@ -75,8 +84,17 @@ void Joystick::RefreshInputState() {
     for (int jind = 0; jind < MAX_JOYSTICKS_NUM; jind++) {
         auto isPresent = glfwJoystickPresent(jind) == GLFW_TRUE;
 
+        // Joystickの接続が外れたフレーム
         if (!isPresent) {
-            joystickInfo_[jind] = nullptr;
+            // if(hidapiDevices_[jind] != nullptr) {
+            //     hidapiDevices_[jind] = nullptr;
+            // }
+
+            if (joystickInfo_[jind] != nullptr) {
+                connectedJoystickCount_--;
+                joystickInfo_[jind] = nullptr;
+            }
+
             continue;
         }
 
@@ -91,19 +109,24 @@ void Joystick::RefreshInputState() {
         for (int i = 0; i < axesCount; ++i) {
             currentAxis_[jind][i] = ax[i];
         }
-
+        
+        // Joystickが接続されたフレーム
         if (joystickInfo_[jind] == nullptr) {
             auto name = glfwGetJoystickName(jind);
             auto guid = glfwGetJoystickGUID(jind);
             joystickInfo_[jind] = MakeAsdShared<JoystickInfo>(utf8_to_utf16(std::string(name)), buttonsCount, axesCount, guid);
+            connectedJoystickCount_++;
+
+            // VendorId, ProductIdをもとにhid_device*を取得してunique_ptrに変換する。
+            // 同じJoystickが接続されている場合にそれらをどうやって区別しよう？
         }
 
-        // auto jtype = GetJoystickType(jind);
-
-        // if (jtype == JoystickType::XBOX360) {
-        //     currentHit[jind][14] = currentAxis_[jind][4] > 0.8;
-        //     currentHit[jind][15] = currentAxis_[jind][5] > 0.8;
-        // }
+        // 特定のジョイスティックに対する補正
+        auto info = joystickInfo_[jind];
+        if (info->IsJoystickType(JoystickType::XBOX360)) {
+            currentHit_[jind][14] = currentAxis_[jind][4] > 0.8;
+            currentHit_[jind][15] = currentAxis_[jind][5] > 0.8;
+        }
     }
 };
 
@@ -111,9 +134,13 @@ bool Joystick::IsPresent(int32_t joystickIndex) const {
     return (0 <= joystickIndex) && (joystickIndex < MAX_JOYSTICKS_NUM) && joystickInfo_[joystickIndex] != nullptr;
 }
 
+int32_t Joystick::GetConnectedJoystickCount() const {
+    return connectedJoystickCount_;
+}
+
 std::shared_ptr<JoystickInfo> Joystick::GetJoystickInfo(int32_t joystickIndex) const {
     if (joystickIndex < 0 || MAX_JOYSTICKS_NUM <= joystickIndex) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetJoystickInfo: joystickIndex '{0}' is out of range.", joystickIndex);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetJoystickInfo: joystickIndex '{0}' is out of range.", joystickIndex);
         return nullptr;
     }
 
@@ -122,13 +149,13 @@ std::shared_ptr<JoystickInfo> Joystick::GetJoystickInfo(int32_t joystickIndex) c
 
 ButtonState Joystick::GetButtonStateByIndex(int32_t joystickIndex, int32_t buttonIndex) const {
     if (!IsPresent(joystickIndex)) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetButtonStateByIndex: Joystick is not present at {0}", joystickIndex);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetButtonStateByIndex: Joystick is not present at {0}", joystickIndex);
         return ButtonState::Free;
     }
 
     auto buttonCount = joystickInfo_[joystickIndex]->GetButtonCount();
     if (buttonIndex < 0 || buttonCount <= buttonIndex) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetButtonStateByIndex: 'buttonIndex: {0}' is out of range, ButtonCount is", buttonIndex, buttonCount);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetButtonStateByIndex: 'buttonIndex: {0}' is out of range, ButtonCount is", buttonIndex, buttonCount);
         return ButtonState::Free;
     }
 
@@ -143,23 +170,40 @@ ButtonState Joystick::GetButtonStateByIndex(int32_t joystickIndex, int32_t butto
 
 ButtonState Joystick::GetButtonStateByType(int32_t joystickIndex, JoystickButtonType type) const {
     if (!IsPresent(joystickIndex)) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetButtonStateByType: Joystick is not present at {0}", joystickIndex);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetButtonStateByType: Joystick is not present at {0}", joystickIndex);
         return ButtonState::Free;
     }
 
-    // TODO
-    return GetButtonStateByIndex(joystickIndex, -1);
+    auto info = joystickInfo_[joystickIndex];
+
+    auto productId = info->GetProduct();
+
+    auto mapping = ButtonMapping.find(productId);
+
+    if (mapping == ButtonMapping.end()) {
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetButtonStateByType: ButtonMapping is not found for joyscitk(index:{0}, name:{1}) ", joystickIndex, utf16_to_utf8(std::u16string(info->GetName())));
+        return ButtonState::Free;
+    }
+
+    auto buttonIndex = mapping->second.find(type);
+
+    if (buttonIndex == mapping->second.end()) {
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetButtonStateByType: Mapping of ButtonType '{0}' is not found for joyscitk(index:{1}, name:{2}) ", static_cast<int32_t>(type), joystickIndex, utf16_to_utf8(std::u16string(info->GetName())));
+        return ButtonState::Free;
+    }
+
+    return GetButtonStateByIndex(joystickIndex, buttonIndex->second);
 };
 
 float Joystick::GetAxisStateByIndex(int32_t joystickIndex, int32_t axisIndex) const {
     if (!IsPresent(joystickIndex)) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetAxisStateByIndex: Joystick is not present at {0}", joystickIndex);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetAxisStateByIndex: Joystick is not present at {0}", joystickIndex);
         return 0.0f;
     }
 
     auto axisCount = joystickInfo_[joystickIndex]->GetAxisCount();
     if (axisIndex < 0 || axisCount <= axisIndex) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetAxisStateByIndex: 'axisIndex: {0}' is out of range, ButtonCount is", axisIndex, axisCount);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetAxisStateByIndex: 'axisIndex: {0}' is out of range, ButtonCount is", axisIndex, axisCount);
         return 0.0f;
     }
 
@@ -168,16 +212,33 @@ float Joystick::GetAxisStateByIndex(int32_t joystickIndex, int32_t axisIndex) co
 
 float Joystick::GetAxisStateByType(int32_t joystickIndex, JoystickAxisType type) const {
     if (!IsPresent(joystickIndex)) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Joystick::GetAxisStateByType: Joystick is not present at {0}", joystickIndex);
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetAxisStateByType: Joystick is not present at {0}", joystickIndex);
         return 0.0f;
     }
 
-    // TODO
-    return GetAxisStateByIndex(joystickIndex, -1);
+    auto info = joystickInfo_[joystickIndex];
+
+    auto productId = info->GetProduct();
+
+    auto mapping = AxisMapping.find(productId);
+
+    if (mapping == AxisMapping.end()) {
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetAxisStateByType: AxisMapping is not found for joyscitk(index:{0}, name:{1}) ", joystickIndex, utf16_to_utf8(std::u16string(info->GetName())));
+        return 0.0f;
+    }
+
+    auto axisIndex = mapping->second.find(type);
+
+    if (axisIndex == mapping->second.end()) {
+        Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::GetAxisStateByType: Mapping of AxisType '{0}' is not found for joyscitk(index:{1}, name:{2}) ", static_cast<int32_t>(type), joystickIndex, utf16_to_utf8(std::u16string(info->GetName())));
+        return 0.0f;
+    }
+
+    return GetAxisStateByIndex(joystickIndex, axisIndex->second);
 };
 
 // void Joystick::Vibrate(int32_t joystickIndex, float frequency, float amplitude) {
-//     Log::GetInstance()->Error(LogCategory::Core, u"Joystick::Vibrate is not supported yet");
+//     Log::GetInstance()->Warn(LogCategory::Core, u"Joystick::Vibrate is not supported yet");
 // }
 
 }  // namespace Altseed

--- a/core/src/Input/Joystick.h
+++ b/core/src/Input/Joystick.h
@@ -20,12 +20,10 @@ enum class JoystickType : int32_t {
     XBOX360 = 654,
     JoyconL = 8198,
     JoyconR = 8199,
+    ProController = 8201,
 };
 
 enum class JoystickButtonType : int32_t {
-    Start,  /// Joycon plus
-    Select,  /// Joycon minus
-
     Home,
     Capture,
 
@@ -43,10 +41,10 @@ enum class JoystickButtonType : int32_t {
 
     L1,
     R1,
-    L2,  // Joycon ZL
-    R2,  // Joycon ZR
-    L3,  // Joycon SL
-    R3,  // Joycon SR
+    L2,
+    R2,
+    L3,  
+    R3,
 
     LeftStart,  ///< XBOX360 Start, PS4 Options
     RightStart,  ///< XBOX360 Select, PS4 TouchPad
@@ -85,6 +83,11 @@ public:
     int32_t GetVendor() const { return vendor_; }
     int32_t GetProduct() const { return product_; }
     int32_t GetVersion() const { return version_; }
+
+    bool IsJoystickType(JoystickType type) const { return product_ == static_cast<int>(type); }
+
+    bool GetIsAvailableButtonMapping() const;
+    bool GetIsAvailableAxisMapping() const;
 };
 
 class Joystick : public BaseObject {
@@ -95,13 +98,16 @@ private:
 
     static std::shared_ptr<Joystick> instance_;
 
+    int32_t connectedJoystickCount_;
+
+    // std::array<std::unique_ptr<hid_device>, MAX_JOYSTICKS_NUM> hidapiDevices_;
+
     std::array<std::shared_ptr<JoystickInfo>, MAX_BUTTONS_NUM> joystickInfo_;
     std::array<std::array<bool, MAX_BUTTONS_NUM>, MAX_JOYSTICKS_NUM> currentHit_;
     std::array<std::array<bool, MAX_BUTTONS_NUM>, MAX_JOYSTICKS_NUM> preHit_;
     std::array<std::array<float, MAX_AXES_NUM>, MAX_JOYSTICKS_NUM> currentAxis_;
 
     std::u16string ToU16(const std::wstring& wstr) const;
-
 
 public:
     Joystick();
@@ -115,6 +121,7 @@ public:
     void RefreshInputState();
 
     bool IsPresent(int32_t joystickIndex) const;
+    int32_t GetConnectedJoystickCount() const;
     std::shared_ptr<JoystickInfo> GetJoystickInfo(int32_t joystickIndex) const;
 
     ButtonState GetButtonStateByIndex(int32_t joystickIndex, int32_t buttonIndex) const;

--- a/core/src/Input/Joystick.h
+++ b/core/src/Input/Joystick.h
@@ -2,10 +2,10 @@
 #include <GLFW/glfw3.h>
 // #include <hidapi.h>
 
-#include <optional>
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <optional>
 
 #include "../Window/Window.h"
 #include "ButtonState.h"
@@ -43,7 +43,7 @@ enum class JoystickButtonType : int32_t {
     R1,
     L2,
     R2,
-    L3,  
+    L3,
     R3,
 
     LeftStart,  ///< XBOX360 Start, PS4 Options
@@ -73,6 +73,7 @@ private:
     int32_t vendor_;
     int32_t product_;
     int32_t version_;
+
 public:
     JoystickInfo(const std::u16string name, const int32_t buttonCount, const int32_t axisCount, const char* guid);
     const char16_t* GetName() const { return name_.c_str(); }

--- a/core/src/Input/Joystick.h
+++ b/core/src/Input/Joystick.h
@@ -1,8 +1,8 @@
 #pragma once
+#include <GLFW/glfw3.h>
+// #include <hidapi.h>
 
-#include <hidapi.h>
-#include <stdio.h>
-
+#include <optional>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -65,6 +65,28 @@ enum class JoystickAxisType : int32_t {
     Max,
 };
 
+class JoystickInfo : BaseObject {
+private:
+    std::u16string name_;
+    int32_t buttonCount_;
+    int32_t axisCount_;
+    std::u16string guid_;
+    int32_t bustype_;
+    int32_t vendor_;
+    int32_t product_;
+    int32_t version_;
+public:
+    JoystickInfo(const std::u16string name, const int32_t buttonCount, const int32_t axisCount, const char* guid);
+    const char16_t* GetName() const { return name_.c_str(); }
+    int32_t GetButtonCount() const { return buttonCount_; }
+    int32_t GetAxisCount() const { return axisCount_; }
+    const char16_t* GetGUID() const { return guid_.c_str(); }
+    int32_t GetBustype() const { return bustype_; }
+    int32_t GetVendor() const { return vendor_; }
+    int32_t GetProduct() const { return product_; }
+    int32_t GetVersion() const { return version_; }
+};
+
 class Joystick : public BaseObject {
 private:
     static const int MAX_AXES_NUM = 10;
@@ -73,21 +95,14 @@ private:
 
     static std::shared_ptr<Joystick> instance_;
 
-    uint8_t globalCount_;
-
-    std::array<hid_device*, MAX_JOYSTICKS_NUM> handler_;
-
-    std::array<JoystickType, MAX_JOYSTICKS_NUM> types_;
-    std::array<std::u16string, MAX_JOYSTICKS_NUM> names_;
-
+    std::array<std::shared_ptr<JoystickInfo>, MAX_BUTTONS_NUM> joystickInfo_;
     std::array<std::array<bool, MAX_BUTTONS_NUM>, MAX_JOYSTICKS_NUM> currentHit_;
     std::array<std::array<bool, MAX_BUTTONS_NUM>, MAX_JOYSTICKS_NUM> preHit_;
-    std::array<std::array<float, MAX_AXES_NUM>, static_cast<int>(JoystickAxisType::Max)> currentAxis_;
+    std::array<std::array<float, MAX_AXES_NUM>, MAX_JOYSTICKS_NUM> currentAxis_;
 
-    std::u16string ToU16(const std::wstring& wstr);
+    std::u16string ToU16(const std::wstring& wstr) const;
 
-    void SendSubcommand(hid_device* dev, uint8_t command, uint8_t data[], int len);
-    void HandleJoyconInput(int index, unsigned char* buff, bool is_left);
+    Joystick();
 
 public:
     static bool Initialize();
@@ -98,21 +113,16 @@ public:
 
     void RefreshInputState();
 
-    void RefreshConnectedState();
-
-    bool IsPresent(int32_t joystickIndex);
+    bool IsPresent(int32_t joystickIndex) const;
+    std::shared_ptr<JoystickInfo> GetJoystickInfo(int32_t index) const;
 
     ButtonState GetButtonStateByIndex(int32_t joystickIndex, int32_t buttonIndex) const;
     ButtonState GetButtonStateByType(int32_t joystickIndex, JoystickButtonType type) const;
 
-    JoystickType GetJoystickType(int32_t index) const;
-
     float GetAxisStateByIndex(int32_t joystickIndex, int32_t axisIndex) const;
     float GetAxisStateByType(int32_t joystickIndex, JoystickAxisType type) const;
 
-    const char16_t* GetJoystickName(int32_t index) const;
-
-    void Vibrate(int32_t joystickIndex, float frequency, float amplitude);
+    // void Vibrate(int32_t joystickIndex, float frequency, float amplitude);
 };
 
 }  // namespace Altseed

--- a/core/src/Input/Joystick.h
+++ b/core/src/Input/Joystick.h
@@ -65,7 +65,7 @@ enum class JoystickAxisType : int32_t {
     Max,
 };
 
-class JoystickInfo : BaseObject {
+class JoystickInfo : public BaseObject {
 private:
     std::u16string name_;
     int32_t buttonCount_;
@@ -102,9 +102,10 @@ private:
 
     std::u16string ToU16(const std::wstring& wstr) const;
 
-    Joystick();
 
 public:
+    Joystick();
+
     static bool Initialize();
 
     static void Terminate();
@@ -114,7 +115,7 @@ public:
     void RefreshInputState();
 
     bool IsPresent(int32_t joystickIndex) const;
-    std::shared_ptr<JoystickInfo> GetJoystickInfo(int32_t index) const;
+    std::shared_ptr<JoystickInfo> GetJoystickInfo(int32_t joystickIndex) const;
 
     ButtonState GetButtonStateByIndex(int32_t joystickIndex, int32_t buttonIndex) const;
     ButtonState GetButtonStateByType(int32_t joystickIndex, JoystickButtonType type) const;

--- a/core/src/Input/JoystickMapping.h
+++ b/core/src/Input/JoystickMapping.h
@@ -1,7 +1,7 @@
 #pragma once
+#include <map>
 
 #include "Joystick.h"
-#include "map"
 
 namespace Altseed {
 
@@ -169,9 +169,9 @@ static const std::map<int32_t, const std::map<JoystickButtonType, int32_t>> Butt
         {static_cast<int32_t>(JoystickType::ProController), ProControllerButtonMapping},
 };
 
-static const std::map<int32_t, const std::map<JoystickAxisType, int32_t>> AxisMapping {
+static const std::map<int32_t, const std::map<JoystickAxisType, int32_t>> AxisMapping{
         {static_cast<int32_t>(JoystickType::DualShock4), DualShock4AxisMapping},
         {static_cast<int32_t>(JoystickType::XBOX360), XBOX360AxisMapping},
         {static_cast<int32_t>(JoystickType::ProController), ProControllerAxisMapping},
 };
-};
+};  // namespace Altseed

--- a/core/src/Input/JoystickMapping.h
+++ b/core/src/Input/JoystickMapping.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "Joystick.h"
+#include "map"
+
+namespace Altseed {
+
+// DualShock4
+static const std::map<JoystickButtonType, int32_t> DualShock4ButtonMapping{
+        {JoystickButtonType::RightLeft, 0},  // Square
+        {JoystickButtonType::RightDown, 1},  // Cross
+        {JoystickButtonType::RightRight, 2},  // Circle
+        {JoystickButtonType::RightUp, 3},  // Triangle
+
+        {JoystickButtonType::L1, 4},
+        {JoystickButtonType::R1, 5},
+        {JoystickButtonType::L2, 6},
+        {JoystickButtonType::R2, 7},
+
+        {JoystickButtonType::LeftPush, 10},
+        {JoystickButtonType::RightPush, 11},
+
+        {JoystickButtonType::LeftUp, 14},
+        {JoystickButtonType::LeftRight, 15},
+        {JoystickButtonType::LeftDown, 16},
+        {JoystickButtonType::LeftLeft, 17},
+
+        {JoystickButtonType::Capture, 8},  // SHARE
+        {JoystickButtonType::RightStart, 9},  // Options
+        {JoystickButtonType::Home, 12},  // Home
+        {JoystickButtonType::LeftStart, 13},  // TouchPad
+};
+
+static const std::map<JoystickAxisType, int32_t> DualShock4AxisMapping{
+        {JoystickAxisType::LeftH, 0},
+        {JoystickAxisType::LeftV, 1},
+        {JoystickAxisType::RightH, 2},
+        {JoystickAxisType::RightV, 5},
+
+        {JoystickAxisType::L2, 3},
+        {JoystickAxisType::R2, 4},
+};
+
+// XBOX360
+static const std::map<JoystickButtonType, int32_t> XBOX360ButtonMapping{
+        {JoystickButtonType::RightLeft, 2},
+        {JoystickButtonType::RightDown, 0},
+        {JoystickButtonType::RightRight, 1},
+        {JoystickButtonType::RightUp, 3},
+
+        {JoystickButtonType::L1, 4},
+        {JoystickButtonType::R1, 5},
+        {JoystickButtonType::L2, 14},
+        {JoystickButtonType::R2, 15},
+
+        {JoystickButtonType::LeftPush, 8},
+        {JoystickButtonType::RightPush, 9},
+
+        {JoystickButtonType::LeftUp, 10},
+        {JoystickButtonType::LeftRight, 11},
+        {JoystickButtonType::LeftDown, 12},
+        {JoystickButtonType::LeftLeft, 13},
+
+        {JoystickButtonType::LeftStart, 6},
+        {JoystickButtonType::RightStart, 7},
+        // {JoystickButtonType::Capture, },
+        // {JoystickButtonType::Home, },
+};
+
+static const std::map<JoystickAxisType, int32_t> XBOX360AxisMapping{
+        {JoystickAxisType::LeftH, 0},
+        {JoystickAxisType::LeftV, 1},
+        {JoystickAxisType::RightH, 2},
+        {JoystickAxisType::RightV, 3},
+
+        {JoystickAxisType::L2, 4},
+        {JoystickAxisType::R2, 5},
+};
+
+// JoyconR
+static const std::map<JoystickButtonType, int32_t> JoyconRButtonMapping{
+        {JoystickButtonType::RightLeft, 2},
+        {JoystickButtonType::RightDown, 0},
+        {JoystickButtonType::RightRight, 1},
+        {JoystickButtonType::RightUp, 3},
+
+        {JoystickButtonType::L1, 4},  // SL
+        {JoystickButtonType::R1, 5},  // SR
+
+        {JoystickButtonType::R2, 14},  // R
+        {JoystickButtonType::R3, 15},  // ZR
+
+        {JoystickButtonType::LeftPush, 11},  // stick
+
+        {JoystickButtonType::LeftUp, 16},
+        {JoystickButtonType::LeftRight, 17},
+        {JoystickButtonType::LeftDown, 18},
+        {JoystickButtonType::LeftLeft, 19},
+
+        {JoystickButtonType::RightStart, 9},
+        {JoystickButtonType::Home, 12},
+};
+
+// JoyconL
+static const std::map<JoystickButtonType, int32_t> JoyconLButtonMapping{
+        {JoystickButtonType::RightLeft, 2},
+        {JoystickButtonType::RightDown, 0},
+        {JoystickButtonType::RightRight, 1},
+        {JoystickButtonType::RightUp, 3},
+
+        {JoystickButtonType::L1, 4},  // SL
+        {JoystickButtonType::R1, 5},  // SR
+
+        {JoystickButtonType::L2, 14},  // L
+        {JoystickButtonType::L3, 15},  // ZL
+
+        {JoystickButtonType::RightPush, 10},  // stick
+
+        {JoystickButtonType::LeftUp, 16},
+        {JoystickButtonType::LeftRight, 17},
+        {JoystickButtonType::LeftDown, 18},
+        {JoystickButtonType::LeftLeft, 19},
+
+        {JoystickButtonType::LeftStart, 8},
+        {JoystickButtonType::Capture, 13},
+};
+
+// ProController
+static const std::map<JoystickButtonType, int32_t> ProControllerButtonMapping{
+        {JoystickButtonType::RightLeft, 2},
+        {JoystickButtonType::RightDown, 0},
+        {JoystickButtonType::RightRight, 1},
+        {JoystickButtonType::RightUp, 3},
+
+        {JoystickButtonType::L1, 4},  // SL
+        {JoystickButtonType::R1, 5},  // SR
+
+        {JoystickButtonType::L2, 6},  // ZL
+        {JoystickButtonType::R2, 7},  // ZR
+
+        {JoystickButtonType::LeftPush, 11},
+        {JoystickButtonType::RightPush, 10},
+
+        {JoystickButtonType::LeftUp, 16},
+        {JoystickButtonType::LeftRight, 17},
+        {JoystickButtonType::LeftDown, 18},
+        {JoystickButtonType::LeftLeft, 19},
+
+        {JoystickButtonType::LeftStart, 8},
+        {JoystickButtonType::RightStart, 9},
+        {JoystickButtonType::Home, 12},
+        {JoystickButtonType::Capture, 12},
+};
+
+static const std::map<JoystickAxisType, int32_t> ProControllerAxisMapping{
+        {JoystickAxisType::LeftH, 0},
+        {JoystickAxisType::LeftV, 1},
+        {JoystickAxisType::RightH, 2},
+        {JoystickAxisType::RightV, 3},
+};
+
+static const std::map<JoystickButtonType, int32_t> pseudo;
+
+static const std::map<int32_t, const std::map<JoystickButtonType, int32_t>> ButtonMapping{
+        {static_cast<int32_t>(JoystickType::DualShock4), DualShock4ButtonMapping},
+        {static_cast<int32_t>(JoystickType::XBOX360), XBOX360ButtonMapping},
+        {static_cast<int32_t>(JoystickType::JoyconR), JoyconRButtonMapping},
+        {static_cast<int32_t>(JoystickType::JoyconL), JoyconLButtonMapping},
+        {static_cast<int32_t>(JoystickType::ProController), ProControllerButtonMapping},
+};
+
+static const std::map<int32_t, const std::map<JoystickAxisType, int32_t>> AxisMapping {
+        {static_cast<int32_t>(JoystickType::DualShock4), DualShock4AxisMapping},
+        {static_cast<int32_t>(JoystickType::XBOX360), XBOX360AxisMapping},
+        {static_cast<int32_t>(JoystickType::ProController), ProControllerAxisMapping},
+};
+};

--- a/core/test/Joystick.cpp
+++ b/core/test/Joystick.cpp
@@ -86,21 +86,82 @@ TEST(Joystick, Initialize) {
             continue;
         }
         std::cout
-            << "Index: " << i
-            << "Name: " << info->GetName() << std::endl
-            << "ButtonCount: " << info->GetButtonCount() << std::endl
-            << "AxisCount: " << info->GetAxisCount() << std::endl
-            << "GUID: " << info->GetGUID() << std::endl
-            << "Bustype: " << info->GetBustype() << std::endl
-            << "Vendor: " << info->GetVendor() << std::endl
-            << "Product: " << info->GetProduct() << std::endl
-            << "Version: " << info->GetVersion() << std::endl
-        ;
+                << "Index: " << i << std::endl
+                << "Name: " << info->GetName() << std::endl
+                << "ButtonCount: " << info->GetButtonCount() << std::endl
+                << "AxisCount: " << info->GetAxisCount() << std::endl
+                << "GUID: " << info->GetGUID() << std::endl
+                << "Bustype: " << info->GetBustype() << std::endl
+                << "Vendor: " << info->GetVendor() << std::endl
+                << "Product: " << info->GetProduct() << std::endl
+                << "Version: " << info->GetVersion() << std::endl;
     }
 
     // if (Altseed::Joystick::GetInstance()->IsPresent(0)) {
     //     CheckVibration(0);
     // }
+
+    Altseed::Core::Terminate();
+}
+
+TEST(Joystick, ButtonState) {
+    char16_t s16[] = u"Initialize";
+
+    EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
+
+    float time = 0.0f;
+    while (Altseed::Core::GetInstance()->DoEvent()) {
+        for (int ji = 0; ji < 16; ji++) {
+            auto info = Altseed::Joystick::GetInstance()->GetJoystickInfo(ji);
+            if (info == nullptr) continue;
+
+            for(int bi = 0; bi < info->GetButtonCount(); bi++) {
+                auto bs = Altseed::Joystick::GetInstance()->GetButtonStateByIndex(ji, bi);
+
+                if (bs == Altseed::ButtonState::Push) {
+                    printf("%d - %d : Push\n", ji, bi);
+                } else if (bs == Altseed::ButtonState::Hold) {
+                    printf("%d - %d : Hold\n", ji, bi);
+                } else if (bs == Altseed::ButtonState::Release) {
+                    printf("%d - %d : Release\n", ji, bi);
+                }
+            }
+
+        }
+
+        time += Altseed::Core::GetInstance()->GetDeltaSecond();
+        if (time > 10.0f) {
+            break;
+        }
+    }
+
+    Altseed::Core::Terminate();
+}
+
+TEST(Joystick, AxisState) {
+    char16_t s16[] = u"Initialize";
+
+    EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
+
+    float time = 0.0f;
+    while (Altseed::Core::GetInstance()->DoEvent()) {
+        for (int ji = 0; ji < 16; ji++) {
+            auto info = Altseed::Joystick::GetInstance()->GetJoystickInfo(ji);
+            if (info == nullptr) continue;
+
+            for (int ai = 0; ai < info->GetAxisCount(); ai++) {
+                auto v = Altseed::Joystick::GetInstance()->GetAxisStateByIndex(ji, ai);
+                if(std::abs(v) > 0.1) {
+                    printf("%d - %d : %f\n", ji, ai, v);
+                }
+            }
+        }
+
+        time += Altseed::Core::GetInstance()->GetDeltaSecond();
+        if (time > 10.0f) {
+            break;
+        }
+    }
 
     Altseed::Core::Terminate();
 }

--- a/core/test/Joystick.cpp
+++ b/core/test/Joystick.cpp
@@ -76,9 +76,10 @@ bool IsPushedOrHolded(int joystickIndex, Altseed::JoystickButtonType btn, int co
 // }
 
 TEST(Joystick, Initialize) {
-    char16_t s16[] = u"Initialize";
+    auto config = Altseed::Configuration::Create();
+    config->SetConsoleLoggingEnabled(true);
 
-    EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
+    EXPECT_TRUE(Altseed::Core::Initialize(u"Joystick Initialize", 640, 480, config));
 
     for (int i = 0; i < 16; i++) {
         auto info = Altseed::Joystick::GetInstance()->GetJoystickInfo(i);
@@ -87,10 +88,10 @@ TEST(Joystick, Initialize) {
         }
         std::cout
                 << "Index: " << i << std::endl
-                << "Name: " << info->GetName() << std::endl
+                << "Name: " << Altseed::utf16_to_utf8(std::u16string(info->GetName())) << std::endl
                 << "ButtonCount: " << info->GetButtonCount() << std::endl
                 << "AxisCount: " << info->GetAxisCount() << std::endl
-                << "GUID: " << info->GetGUID() << std::endl
+                << "GUID: " << Altseed::utf16_to_utf8(std::u16string(info->GetGUID())) << std::endl
                 << "Bustype: " << info->GetBustype() << std::endl
                 << "Vendor: " << info->GetVendor() << std::endl
                 << "Product: " << info->GetProduct() << std::endl
@@ -105,9 +106,10 @@ TEST(Joystick, Initialize) {
 }
 
 TEST(Joystick, ButtonState) {
-    char16_t s16[] = u"Initialize";
+    auto config = Altseed::Configuration::Create();
+    config->SetConsoleLoggingEnabled(true);
 
-    EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
+    EXPECT_TRUE(Altseed::Core::Initialize(u"Joystick ButtonState", 640, 480, config));
 
     float time = 0.0f;
     while (Altseed::Core::GetInstance()->DoEvent()) {
@@ -139,9 +141,10 @@ TEST(Joystick, ButtonState) {
 }
 
 TEST(Joystick, AxisState) {
-    char16_t s16[] = u"Initialize";
+    auto config = Altseed::Configuration::Create();
+    config->SetConsoleLoggingEnabled(true);
 
-    EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
+    EXPECT_TRUE(Altseed::Core::Initialize(u"Joystick AxisState", 640, 480, config));
 
     float time = 0.0f;
     while (Altseed::Core::GetInstance()->DoEvent()) {
@@ -153,6 +156,111 @@ TEST(Joystick, AxisState) {
                 auto v = Altseed::Joystick::GetInstance()->GetAxisStateByIndex(ji, ai);
                 if(std::abs(v) > 0.1) {
                     printf("%d - %d : %f\n", ji, ai, v);
+                }
+            }
+        }
+
+        time += Altseed::Core::GetInstance()->GetDeltaSecond();
+        if (time > 10.0f) {
+            break;
+        }
+    }
+
+    Altseed::Core::Terminate();
+}
+
+TEST(Joystick, ButtonStateByType) {
+    const std::map<std::string, Altseed::JoystickButtonType> buttonTypes {
+            {std::string("Home"), Altseed::JoystickButtonType::Home},
+            {std::string("Capture"), Altseed::JoystickButtonType::Capture},
+
+            {std::string("LeftUp"), Altseed::JoystickButtonType::LeftUp},
+            {std::string("LeftDown"), Altseed::JoystickButtonType::LeftDown},
+            {std::string("LeftLeft"), Altseed::JoystickButtonType::LeftLeft},
+            {std::string("LeftRight"), Altseed::JoystickButtonType::LeftRight},
+            {std::string("LeftPush"), Altseed::JoystickButtonType::LeftPush},
+
+            {std::string("RightUp"), Altseed::JoystickButtonType::RightUp},
+            {std::string("RightRight"), Altseed::JoystickButtonType::RightRight},
+            {std::string("RightLeft"), Altseed::JoystickButtonType::RightLeft},
+            {std::string("RightDown"), Altseed::JoystickButtonType::RightDown},
+            {std::string("RightPush"), Altseed::JoystickButtonType::RightPush},
+
+            {std::string("L1"), Altseed::JoystickButtonType::L1},
+            {std::string("R1"), Altseed::JoystickButtonType::R1},
+            {std::string("L2"), Altseed::JoystickButtonType::L2},
+            {std::string("R2"), Altseed::JoystickButtonType::R2},
+            {std::string("L3"), Altseed::JoystickButtonType::L3},
+            {std::string("R3"), Altseed::JoystickButtonType::R3},
+    
+            {std::string("LeftStart"), Altseed::JoystickButtonType::LeftStart},
+            {std::string("RightStart"), Altseed::JoystickButtonType::RightStart},
+    };
+
+    auto config = Altseed::Configuration::Create();
+    // config->SetConsoleLoggingEnabled(true);
+
+    EXPECT_TRUE(Altseed::Core::Initialize(u"Joystick ButtonStateByType", 640, 480, config));
+
+    float time = 0.0f;
+    while (Altseed::Core::GetInstance()->DoEvent()) {
+        for (int ji = 0; ji < 16; ji++) {
+            auto info = Altseed::Joystick::GetInstance()->GetJoystickInfo(ji);
+            if (info == nullptr) continue;
+
+            for(auto const& x : buttonTypes) {
+                auto bs = Altseed::Joystick::GetInstance()->GetButtonStateByType(ji, x.second);
+                    if (bs == Altseed::ButtonState::Push) {
+                        printf("%d - %s : Push\n", ji, x.first.c_str());
+                    } else if (bs == Altseed::ButtonState::Release) {
+                        printf("%d - %s : Release\n", ji, x.first.c_str());
+                    }
+            }
+        }
+
+        time += Altseed::Core::GetInstance()->GetDeltaSecond();
+        if (time > 10.0f) {
+            break;
+        }
+    }
+
+    Altseed::Core::Terminate();
+}
+
+TEST(Joystick, AxisStateByType) {
+    const std::map<std::string, Altseed::JoystickAxisType> axisTypes{
+            {std::string("LeftH"), Altseed::JoystickAxisType::LeftH},
+            {std::string("LeftV"), Altseed::JoystickAxisType::LeftV},
+            {std::string("RightH"), Altseed::JoystickAxisType::RightH},
+            {std::string("RightV"), Altseed::JoystickAxisType::RightV},
+    };
+
+    auto config = Altseed::Configuration::Create();
+
+    EXPECT_TRUE(Altseed::Core::Initialize(u"Joystick ButtonStateByType", 640, 480, config));
+
+    float time = 0.0f;
+    while (Altseed::Core::GetInstance()->DoEvent()) {
+        for (int ji = 0; ji < 16; ji++) {
+            auto info = Altseed::Joystick::GetInstance()->GetJoystickInfo(ji);
+            if (info == nullptr) continue;
+
+            for (auto const& x : axisTypes) {
+                auto as = Altseed::Joystick::GetInstance()->GetAxisStateByType(ji, x.second);
+                if(std::abs(as) > 0.1) {
+                    printf("%d - %s : %f\n", ji, x.first.c_str(), as);
+                }
+            }
+            {
+                auto as = Altseed::Joystick::GetInstance()->GetAxisStateByType(ji, Altseed::JoystickAxisType::R2);
+                if (as > -0.5) {
+                    printf("%d - R2 : %f\n", ji, as);
+                }
+            }
+            {
+                auto as = Altseed::Joystick::GetInstance()->GetAxisStateByType(ji, Altseed::JoystickAxisType::L2);
+                if (as > -0.5) {
+                    printf("%d - L2 : %f\n", ji, as);
                 }
             }
         }

--- a/core/test/Joystick.cpp
+++ b/core/test/Joystick.cpp
@@ -18,61 +18,62 @@ bool IsPushedOrHolded(int joystickIndex, Altseed::JoystickButtonType btn, int co
     }
 }
 
-void CheckVibration(int joystickIndex) {
-    int vibrate_time = 500;  // milliseconds
-    float frequency = 150.0f;
-    float amplitude = 0.8f;
-    int32_t count = 0;
-    std::chrono::system_clock::time_point start, end;
-    start = std::chrono::system_clock::now();
-    end = std::chrono::system_clock::now();
-    bool vibrated = false;
+// TODO
+// void CheckVibration(int joystickIndex) {
+//     int vibrate_time = 500;  // milliseconds
+//     float frequency = 150.0f;
+//     float amplitude = 0.8f;
+//     int32_t count = 0;
+//     std::chrono::system_clock::time_point start, end;
+//     start = std::chrono::system_clock::now();
+//     end = std::chrono::system_clock::now();
+//     bool vibrated = false;
 
-    while (true) {
-        Altseed::Joystick::GetInstance()->RefreshInputState();
+//     while (true) {
+//         Altseed::Joystick::GetInstance()->RefreshInputState();
 
-        if (!vibrated && Altseed::Joystick::GetInstance()->GetButtonStateByType(joystickIndex, Altseed::JoystickButtonType::RightDown) ==
-                                 Altseed::ButtonState::Push) {
-            Altseed::Joystick::GetInstance()->Vibrate(joystickIndex, frequency, amplitude);
-            start = std::chrono::system_clock::now();
-            vibrated = true;
-        }
+//         if (!vibrated && Altseed::Joystick::GetInstance()->GetButtonStateByType(joystickIndex, Altseed::JoystickButtonType::RightDown) ==
+//                                  Altseed::ButtonState::Push) {
+//             Altseed::Joystick::GetInstance()->Vibrate(joystickIndex, frequency, amplitude);
+//             start = std::chrono::system_clock::now();
+//             vibrated = true;
+//         }
 
-        if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::RightRight, count)) {
-            frequency += 10.0f;
-            std::cout << "freq: " << frequency << std::endl;
-        }
-        if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::RightLeft, count)) {
-            frequency -= 10.0f;
-            std::cout << "freq: " << frequency << std::endl;
-        }
-        if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::R3, count)) {
-            amplitude += 0.05f;
-            std::cout << "amp : " << amplitude << std::endl;
-        }
-        if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::L3, count)) {
-            amplitude -= 0.05f;
-            ;
-            std::cout << "amp : " << amplitude << std::endl;
-        }
-        if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::R2, count)) {
-            vibrate_time += 10.0f;
-            std::cout << "time: " << vibrate_time << std::endl;
-        }
-        if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::R1, count)) {
-            vibrate_time -= 10.0f;
-            std::cout << "time: " << vibrate_time << std::endl;
-        }
+//         if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::RightRight, count)) {
+//             frequency += 10.0f;
+//             std::cout << "freq: " << frequency << std::endl;
+//         }
+//         if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::RightLeft, count)) {
+//             frequency -= 10.0f;
+//             std::cout << "freq: " << frequency << std::endl;
+//         }
+//         if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::R3, count)) {
+//             amplitude += 0.05f;
+//             std::cout << "amp : " << amplitude << std::endl;
+//         }
+//         if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::L3, count)) {
+//             amplitude -= 0.05f;
+//             ;
+//             std::cout << "amp : " << amplitude << std::endl;
+//         }
+//         if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::R2, count)) {
+//             vibrate_time += 10.0f;
+//             std::cout << "time: " << vibrate_time << std::endl;
+//         }
+//         if (IsPushedOrHolded(joystickIndex, Altseed::JoystickButtonType::R1, count)) {
+//             vibrate_time -= 10.0f;
+//             std::cout << "time: " << vibrate_time << std::endl;
+//         }
 
-        if (vibrated && std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() >= vibrate_time) {
-            Altseed::Joystick::GetInstance()->Vibrate(joystickIndex, 100.0f, 0);
-            vibrated = false;
-        }
+//         if (vibrated && std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() >= vibrate_time) {
+//             Altseed::Joystick::GetInstance()->Vibrate(joystickIndex, 100.0f, 0);
+//             vibrated = false;
+//         }
 
-        end = std::chrono::system_clock::now();
-        count++;
-    }
-}
+//         end = std::chrono::system_clock::now();
+//         count++;
+//     }
+// }
 
 TEST(Joystick, Initialize) {
     char16_t s16[] = u"Initialize";
@@ -80,16 +81,26 @@ TEST(Joystick, Initialize) {
     EXPECT_TRUE(Altseed::Core::Initialize(s16, 640, 480, Altseed::Configuration::Create()));
 
     for (int i = 0; i < 16; i++) {
-        if (Altseed::Joystick::GetInstance()->IsPresent(i)) {
-            std::cout << "name : " << Altseed::utf16_to_utf8(std::u16string(Altseed::Joystick::GetInstance()->GetJoystickName(i)))
-                      << std::endl;
-            std::cout << "index : " << i << std::endl;
+        auto info = Altseed::Joystick::GetInstance()->GetJoystickInfo(i);
+        if (info == nullptr) {
+            continue;
         }
+        std::cout
+            << "Index: " << i
+            << "Name: " << info->GetName() << std::endl
+            << "ButtonCount: " << info->GetButtonCount() << std::endl
+            << "AxisCount: " << info->GetAxisCount() << std::endl
+            << "GUID: " << info->GetGUID() << std::endl
+            << "Bustype: " << info->GetBustype() << std::endl
+            << "Vendor: " << info->GetVendor() << std::endl
+            << "Product: " << info->GetProduct() << std::endl
+            << "Version: " << info->GetVersion() << std::endl
+        ;
     }
 
-    if (Altseed::Joystick::GetInstance()->IsPresent(0)) {
-        CheckVibration(0);
-    }
+    // if (Altseed::Joystick::GetInstance()->IsPresent(0)) {
+    //     CheckVibration(0);
+    // }
 
     Altseed::Core::Terminate();
 }

--- a/core/test/Joystick.cpp
+++ b/core/test/Joystick.cpp
@@ -164,7 +164,7 @@ TEST(Joystick, AxisState) {
 
     if (joystickCount > 0) {
         printJoystickInformation();
-        
+
         float time = 0.0f;
         while (Altseed::Core::GetInstance()->DoEvent()) {
             for (int ji = 0; ji < 16; ji++) {
@@ -173,7 +173,7 @@ TEST(Joystick, AxisState) {
 
                 for (int ai = 0; ai < info->GetAxisCount(); ai++) {
                     auto v = Altseed::Joystick::GetInstance()->GetAxisStateByIndex(ji, ai);
-                    if(std::abs(v) > 0.1) {
+                    if (std::abs(v) > 0.1) {
                         printf("%d - %d : %f\n", ji, ai, v);
                     }
                 }
@@ -192,7 +192,7 @@ TEST(Joystick, AxisState) {
 }
 
 TEST(Joystick, ButtonStateByType) {
-    const std::map<std::string, Altseed::JoystickButtonType> buttonTypes {
+    const std::map<std::string, Altseed::JoystickButtonType> buttonTypes{
             {std::string("Home"), Altseed::JoystickButtonType::Home},
             {std::string("Capture"), Altseed::JoystickButtonType::Capture},
 
@@ -214,7 +214,7 @@ TEST(Joystick, ButtonStateByType) {
             {std::string("R2"), Altseed::JoystickButtonType::R2},
             {std::string("L3"), Altseed::JoystickButtonType::L3},
             {std::string("R3"), Altseed::JoystickButtonType::R3},
-    
+
             {std::string("LeftStart"), Altseed::JoystickButtonType::LeftStart},
             {std::string("RightStart"), Altseed::JoystickButtonType::RightStart},
     };

--- a/scripts/bindings/define.py
+++ b/scripts/bindings/define.py
@@ -72,6 +72,7 @@ define.enums.append(JoystickAxisType)
 define.classes.append(Cursor)
 define.classes.append(Keyboard)
 define.classes.append(Mouse)
+define.classes.append(JoystickInfo)
 define.classes.append(Joystick)
 
 # graphics

--- a/scripts/bindings/input.py
+++ b/scripts/bindings/input.py
@@ -442,13 +442,54 @@ with JoystickAxisType as enum:
     enum.add('R2')
     enum.add('Max')
 
+JoystickInfo = cbg.Class('Altseed', 'JoystickInfo')
+with JoystickInfo as class_:
+    with class_.add_property(ctypes.c_wchar_p, 'Name') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(int, 'ButtonCount') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(int, 'AxisCount') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(ctypes.c_wchar_p, 'GUID') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(int, 'Bustype') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(int, 'Vendor') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(int, 'Product') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(int, 'Version') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
 Joystick = cbg.Class('Altseed', 'Joystick')
 with Joystick as class_:
     class_.brief = cbg.Description()
     class_.brief.add('ja', 'ジョイスティックを表すクラス')
     class_.is_Sealed = True
 
-    # Core 内部で呼び出されるので Initialize は Engineに公開しない
     with class_.add_func('GetInstance') as func:
         func.brief = cbg.Description()
         func.brief.add('ja', 'インスタンスを取得します。')
@@ -457,21 +498,27 @@ with Joystick as class_:
         func.return_value.brief.add('ja', '使用するインスタンス')
         func.is_public = False
         func.is_static = True
+
     with class_.add_func('IsPresent') as func:
         func.brief = cbg.Description()
-        func.brief.add('ja', '指定したジョイスティックが親であるかどうかを取得します。')
+        func.brief.add('ja', '指定したジョイスティックが存在しているかどうかを取得します。')
         with func.add_arg(int, 'joystickIndex') as arg:
             arg.brief = cbg.Description()
             arg.brief.add('ja', 'ジョイスティックのインデックス')
         func.return_value.type_ = bool
         func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定したジョイスティックが親であったらtrue，それ以外でfalse')
-    # with class_.add_func('RefreshInputState') as func:
-    #     func.brief = cbg.Description()
-    #     func.brief.add('ja', 'インプットの状態をリセットします。')
-    with class_.add_func('RefreshConnectedState') as func:
+        func.return_value.brief.add('ja', '指定したジョイスティックが存在したらtrue，存在していなかったらfalse')
+        
+    with class_.add_func('GetJoystickInfo') as func:
         func.brief = cbg.Description()
-        func.brief.add('ja', '接続の状態をリセットします。')
+        func.brief.add('ja', '指定したジョイスティックの情報を取得します。')
+
+        with func.add_arg(int, 'joystickIndex') as arg:
+            arg.brief = cbg.Description()
+            arg.brief.add('ja', 'ジョイスティックのインデックス')
+
+        func.return_value.type_ = JoystickInfo
+
     with class_.add_func('GetButtonStateByIndex') as func:
         func.brief = cbg.Description()
         func.brief.add('ja', 'ボタンの状態をインデックスで取得します。')
@@ -486,6 +533,7 @@ with Joystick as class_:
         func.return_value.brief.add('ja', '指定インデックスのボタンの状態')
         func.is_public = False
         func.onlyExtern = True
+
     with class_.add_func('GetButtonStateByType') as func:
         func.brief = cbg.Description()
         func.brief.add('ja', 'ボタンの状態を種類から取得します。')
@@ -500,15 +548,7 @@ with Joystick as class_:
         func.return_value.brief.add('ja', '指定種類のボタンの状態')
         func.is_public = False
         func.onlyExtern = True
-    with class_.add_func('GetJoystickType') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', '指定インデックスのジョイスティックの種類を取得します。')
-        with func.add_arg(int, 'index') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', '種類を取得するジョイスティックのインデックス')
-        func.return_value.type_ = JoystickType
-        func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定インデックスのジョイスティックの種類')
+
     with class_.add_func('GetAxisStateByIndex') as func:
         func.brief = cbg.Description()
         func.brief.add('ja', '軸の状態をインデックスで取得します。')
@@ -523,6 +563,7 @@ with Joystick as class_:
         func.return_value.brief.add('ja', '指定インデックスの軸の状態')
         func.is_public = False
         func.onlyExtern = True
+
     with class_.add_func('GetAxisStateByType') as func:
         func.brief = cbg.Description()
         func.brief.add('ja', '軸の状態を軸の種類で取得します。')
@@ -537,27 +578,16 @@ with Joystick as class_:
         func.return_value.brief.add('ja', '指定種類の軸の状態')
         func.is_public = False
         func.onlyExtern = True
-    with class_.add_func('GetJoystickName') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', 'ジョイスティックの名前を取得します。')
-        with func.add_arg(int, 'index') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', '名前を検索するジョイスティックのインデックス')
-        func.return_value.type_ = ctypes.c_wchar_p
-        func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定したインデックスのジョイスティックの名前')
-    # with class_.add_func('RefreshVibrateState') as func:
+
+    # with class_.add_func('Vibrate') as func:
     #     func.brief = cbg.Description()
-    #     func.brief.add('ja', '振動の状態をリセットします。')
-    with class_.add_func('Vibrate') as func:
-        func.brief = cbg.Description()
-        func.brief.add('ja', '指定したジョイスティックコントローラーを振動させます')
-        with func.add_arg(int, 'index') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', 'ジョイスティックのインデックス')
-        with func.add_arg(float, 'frequency') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', '周波数')
-        with func.add_arg(float, 'amplitude') as arg:
-            arg.brief = cbg.Description()
-            arg.brief.add('ja', '振幅')
+    #     func.brief.add('ja', '指定したジョイスティックコントローラーを振動させます。')
+    #     with func.add_arg(int, 'index') as arg:
+    #         arg.brief = cbg.Description()
+    #         arg.brief.add('ja', 'ジョイスティックのインデックス')
+    #     with func.add_arg(float, 'frequency') as arg:
+    #         arg.brief = cbg.Description()
+    #         arg.brief.add('ja', '周波数')
+    #     with func.add_arg(float, 'amplitude') as arg:
+    #         arg.brief = cbg.Description()
+    #         arg.brief.add('ja', '振幅')

--- a/scripts/bindings/input.py
+++ b/scripts/bindings/input.py
@@ -470,16 +470,40 @@ with JoystickInfo as class_:
         prop_.is_public = True
 
     with class_.add_property(int, 'Vendor') as prop_:
+        prop_.brief = cbg.Description()
+        prop_.brief.add('ja', '製造者IDを取得します。')
         prop_.has_getter = True
         prop_.has_setter = False
         prop_.is_public = True
 
     with class_.add_property(int, 'Product') as prop_:
+        prop_.brief = cbg.Description()
+        prop_.brief.add('ja', '製品IDを取得します。')
         prop_.has_getter = True
         prop_.has_setter = False
         prop_.is_public = True
 
     with class_.add_property(int, 'Version') as prop_:
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_func('IsJoystickType') as func:
+        func.brief = cbg.Description()
+        func.brief.add('ja', '指定したジョイスティックの種類に合致するかどうかを取得します。')
+        func.add_arg(JoystickType, 'type')
+        func.return_value.type_ = bool
+
+    with class_.add_property(bool, 'IsAvailableButtonMapping') as prop_:
+        prop_.brief = cbg.Description()
+        prop_.brief.add('ja', 'ButtonTypeを利用してボタンの状態を取得できるかどうかを取得します。')
+        prop_.has_getter = True
+        prop_.has_setter = False
+        prop_.is_public = True
+
+    with class_.add_property(bool, 'IsAvailableAxisMapping') as prop_:
+        prop_.brief = cbg.Description()
+        prop_.brief.add('ja', 'AxisTypeを利用して軸の状態を取得できるかどうかを取得します。')
         prop_.has_getter = True
         prop_.has_setter = False
         prop_.is_public = True
@@ -508,6 +532,13 @@ with Joystick as class_:
         func.return_value.type_ = bool
         func.return_value.brief = cbg.Description()
         func.return_value.brief.add('ja', '指定したジョイスティックが存在したらtrue，存在していなかったらfalse')
+
+    with class_.add_property(int, 'ConnectedJoystickCount') as prop:
+        prop.brief = cbg.Description()
+        prop.brief.add('ja', '接続されているジョイスティックの数を取得します。')
+        prop.has_getter = True
+        prop.has_setter = True
+        prop.is_public = True
         
     with class_.add_func('GetJoystickInfo') as func:
         func.brief = cbg.Description()
@@ -530,7 +561,7 @@ with Joystick as class_:
             arg.brief.add('ja', '状態を検索するボタンのインデックス')
         func.return_value.type_ = ButtonState
         func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定インデックスのボタンの状態')
+        func.return_value.brief.add('ja', 'ボタンの状態')
         func.is_public = False
         func.onlyExtern = True
 
@@ -545,7 +576,7 @@ with Joystick as class_:
             arg.brief.add('ja', '状態を検索するボタンの種類')
         func.return_value.type_ = ButtonState
         func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定種類のボタンの状態')
+        func.return_value.brief.add('ja', 'ボタンの状態')
         func.is_public = False
         func.onlyExtern = True
 
@@ -560,7 +591,7 @@ with Joystick as class_:
             arg.brief.add('ja', '状態を検索する軸のインデックス')
         func.return_value.type_ = float
         func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定インデックスの軸の状態')
+        func.return_value.brief.add('ja', '軸の状態')
         func.is_public = False
         func.onlyExtern = True
 
@@ -575,7 +606,7 @@ with Joystick as class_:
             arg.brief.add('ja', '状態を検索する軸の種類')
         func.return_value.type_ = float
         func.return_value.brief = cbg.Description()
-        func.return_value.brief.add('ja', '指定種類の軸の状態')
+        func.return_value.brief.add('ja', '軸の状態')
         func.is_public = False
         func.onlyExtern = True
 

--- a/scripts/bindings/input.py
+++ b/scripts/bindings/input.py
@@ -537,7 +537,7 @@ with Joystick as class_:
         prop.brief = cbg.Description()
         prop.brief.add('ja', '接続されているジョイスティックの数を取得します。')
         prop.has_getter = True
-        prop.has_setter = True
+        prop.has_setter = False
         prop.is_public = True
         
     with class_.add_func('GetJoystickInfo') as func:


### PR DESCRIPTION
現状:
ひとまずglfwによる実装に差し替えた。
`GetJoystickInfo` で `JoystickInfo` class を取得して、そこから
- `Name`
- `ButtonCount`
- `AxisCount`
- `GUID`
- `Bustype`
- `Vendor`
- `Product`
- `Version`
を取得できる。
これはあくまでもReadOnlyなデータを格納することを想定。

その辺のinterfaceは `Joystick.h`  を参照。

重要な注意点として、`RefreshInputState` 時に接続状態が変わったindexのJoystickInfoを更新する形にした。つまり、Joystickを繋いだり外したりしても`RefreshInputState`(Core::DoEventで呼ばれている)のタイミングで自動で反映されるようになっている。

`GetButtonStateByType`, `GetAxisStateByType` は Dualshock4, XBOX360, JoyconL, JoyconR, ProControllerに対応してある。 `JoystickMapping.h` に対応する辞書を記述して追加可能。

課題：
hidapi実装はFirst Release以降になりそう。

hidapiを利用する際には、`Vendor`と`Product`の値を利用できるが、
同じ種類のコントローラーが複数接続された際にどうやって判定するのがいいのか(hidapi内では`serial_number`で区別しているようだが、glfwからそんな値は取得できない。