### PR TITLE
Fix CoreModules and Test and Sound for CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
           targetType: 'inline'
           script: |
             cd build/RELEASE/
-            .\Altseed2_Core_Test.exe
+            .\Altseed2_Core_Test.exe --gtest_filter='-Sound.*'
 
       - task: PublishBuildArtifacts@1
         inputs:

--- a/core/src/Core.cpp
+++ b/core/src/Core.cpp
@@ -249,15 +249,29 @@ std::shared_ptr<Core>& Core::GetInstance() { return instance; }
 Core::Core() : maxBaseObjectId_(0) {}
 
 bool Core::DoEvent() {
-    Altseed2::Keyboard::GetInstance()->RefleshKeyStates();
-    Altseed2::Mouse::GetInstance()->RefreshInputState();
-    Altseed2::Joystick::GetInstance()->RefreshInputState();
+    auto coreModules = Core::instance->config_->GetEnabledCoreModules();
+
+    if (CoreModulesHasBit(coreModules, CoreModules::Keyboard)) {
+        Altseed2::Keyboard::GetInstance()->RefleshKeyStates();
+    }
+
+    if (CoreModulesHasBit(coreModules, CoreModules::Mouse)) {
+        Altseed2::Mouse::GetInstance()->RefreshInputState();
+    }
+
+    if (CoreModulesHasBit(coreModules, CoreModules::Joystick)) {
+        Altseed2::Joystick::GetInstance()->RefreshInputState();
+    }
 
     SynchronizationContext::GetInstance()->Run();
 
     Core::instance->fps_->Update();
 
-    return Altseed2::Window::GetInstance()->DoEvent();
+    if (CoreModulesHasBit(coreModules, CoreModules::RequireWindow)) {
+        return Altseed2::Window::GetInstance()->DoEvent();
+    } else {
+        return true;
+    }
 }
 
 const float Core::GetDeltaSecond() { return Core::instance->fps_->GetDeltaSecond(); }

--- a/core/src/Graphics/ImageFont.cpp
+++ b/core/src/Graphics/ImageFont.cpp
@@ -1,4 +1,5 @@
 ﻿#include "ImageFont.h"
+
 #include <string>
 
 #include "../IO/File.h"

--- a/core/src/Graphics/RenderTexture.cpp
+++ b/core/src/Graphics/RenderTexture.cpp
@@ -15,7 +15,13 @@ RenderTexture::RenderTexture(const std::shared_ptr<LLGI::Texture>& texture)
 RenderTexture::~RenderTexture() {}
 
 std::shared_ptr<RenderTexture> RenderTexture::Create(Vector2I size, TextureFormatType format) {
-    auto texture = Graphics::GetInstance()->CreateRenderTexture(size.X, size.Y, format);
+    auto graphics = Graphics::GetInstance();
+    if (graphics == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Graphics is not initialized.");
+        return nullptr;
+    }
+
+    auto texture = graphics->CreateRenderTexture(size.X, size.Y, format);
 
     if (texture == nullptr) {
         Log::GetInstance()->Error(LogCategory::Core, u"RenderTexture::Create: Failed to CreateTexture");

--- a/core/src/Graphics/Shader.cpp
+++ b/core/src/Graphics/Shader.cpp
@@ -21,14 +21,26 @@ std::shared_ptr<ShaderCompileResult> Shader::Compile(const char16_t* name, const
     RETURN_IF_NULL(name, MakeAsdShared<ShaderCompileResult>(nullptr, u"name is null"));
     RETURN_IF_NULL(code, MakeAsdShared<ShaderCompileResult>(nullptr, u"code is null"));
 
-    return ShaderCompiler::GetInstance()->Compile("", utf16_to_utf8(name).c_str(), utf16_to_utf8(code).c_str(), shaderStage);
+    auto shaderCompiler = ShaderCompiler::GetInstance();
+    if (shaderCompiler == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Graphics is not initialized.");
+        return nullptr;
+    }
+
+    return shaderCompiler->Compile("", utf16_to_utf8(name).c_str(), utf16_to_utf8(code).c_str(), shaderStage);
 }
 
 std::shared_ptr<ShaderCompileResult> Shader::CompileFromFile(const char16_t* name, const char16_t* path, ShaderStageType shaderStage) {
     RETURN_IF_NULL(name, MakeAsdShared<ShaderCompileResult>(nullptr, u"name is null"));
     RETURN_IF_NULL(path, MakeAsdShared<ShaderCompileResult>(nullptr, u"path is null"));
 
-    return ShaderCompiler::GetInstance()->Compile(utf16_to_utf8(path).c_str(), utf16_to_utf8(name).c_str(), shaderStage);
+    auto shaderCompiler = ShaderCompiler::GetInstance();
+    if (shaderCompiler == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Graphics is not initialized.");
+        return nullptr;
+    }
+
+    return shaderCompiler->Compile(utf16_to_utf8(path).c_str(), utf16_to_utf8(name).c_str(), shaderStage);
 }
 
 }  // namespace Altseed2

--- a/core/src/Graphics/Texture2D.cpp
+++ b/core/src/Graphics/Texture2D.cpp
@@ -32,9 +32,14 @@ const char16_t* Texture2D::GetPath() const { return sourcePath_.c_str(); }
 std::shared_ptr<Texture2D> Texture2D::Load(const char16_t* path) {
     RETURN_IF_NULL(path, nullptr);
 
+    auto resources = Resources::GetInstance();
+    if (resources == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Resources is not initialized.");
+        return nullptr;
+    }
+
     std::lock_guard<std::mutex> lock(mtx);
 
-    auto resources = Resources::GetInstance();
     auto cache = std::dynamic_pointer_cast<Texture2D>(resources->GetResourceContainer(ResourceType::Texture2D)->Get(path));
     if (cache != nullptr && cache->GetRef() > 0) {
         return cache;

--- a/core/src/IO/StaticFile.cpp
+++ b/core/src/IO/StaticFile.cpp
@@ -37,11 +37,16 @@ StaticFile::~StaticFile() {
 std::shared_ptr<StaticFile> StaticFile::Create(const char16_t* path) {
     RETURN_IF_NULL(path, nullptr);
 
+    auto resources = Resources::GetInstance();
+    if (resources == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"File is not initialized.");
+        return nullptr;
+    }
+
     std::lock_guard<std::mutex> lock(m_staticFileMtx);
 
     auto path_ = FileSystem::NormalizePath(path);
 
-    auto resources = Resources::GetInstance();
     auto cache = std::dynamic_pointer_cast<StaticFile>(resources->GetResourceContainer(ResourceType::StaticFile)->Get(path_));
     if (cache != nullptr && cache->GetRef() > 0) {
         return cache;

--- a/core/src/IO/StreamFile.cpp
+++ b/core/src/IO/StreamFile.cpp
@@ -22,11 +22,16 @@ StreamFile::~StreamFile() {
 std::shared_ptr<StreamFile> StreamFile::Create(const char16_t* path) {
     RETURN_IF_NULL(path, nullptr);
 
+    auto resources = Resources::GetInstance();
+    if (resources == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"File is not initialized.");
+        return nullptr;
+    }
+
     std::lock_guard<std::mutex> lock(m_streamFileMtx);
 
     auto path_ = FileSystem::NormalizePath(path);
 
-    auto resources = Resources::GetInstance();
     auto cache = std::dynamic_pointer_cast<StreamFile>(resources->GetResourceContainer(ResourceType::StreamFile)->Get(path_));
     if (cache != nullptr && cache->GetRef() > 0) {
         return cache;

--- a/core/src/Sound/Sound.cpp
+++ b/core/src/Sound/Sound.cpp
@@ -20,11 +20,18 @@ Sound::~Sound() {
 std::shared_ptr<Sound> Sound::Load(const char16_t* path, bool isDecompressed) {
     RETURN_IF_NULL(path, nullptr);
 
-    std::lock_guard<std::mutex> lock(mtx);
-
     auto soundMixer = SoundMixer::GetInstance();
-    if (!soundMixer->isSoundMixerEnabled_) return nullptr;
-    if (soundMixer->m_manager == nullptr) return nullptr;
+    if (soundMixer == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not initialized.");
+        return nullptr;
+    }
+
+    if (soundMixer->m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
 
     auto cache = std::dynamic_pointer_cast<Sound>(soundMixer->m_resources->GetResourceContainer(ResourceType::Sound)->Get(path));
     if (cache != nullptr && cache->GetRef() > 0) {

--- a/core/src/Sound/SoundMixer.cpp
+++ b/core/src/Sound/SoundMixer.cpp
@@ -16,7 +16,8 @@ bool SoundMixer::Initialize(bool isReloadingEnabled) {
     instance_->m_resources = Resources::GetInstance();
 
     if (!instance_->m_manager->Initialize()) {
-        instance_->isSoundMixerEnabled_ = false;
+        instance_->m_manager = nullptr;
+        instance_->m_resources = nullptr;
     }
 
     return true;
@@ -26,132 +27,170 @@ void SoundMixer::Terminate() {
     if (instance_->m_manager != nullptr) {
         instance_->m_manager->Finalize();
     }
-
+    instance_->m_resources = nullptr;
     instance_ = nullptr;
 }
 
 std::shared_ptr<SoundMixer>& SoundMixer::GetInstance() { return instance_; }
 
 int32_t SoundMixer::Play(std::shared_ptr<Sound> sound) {
-    if (!isSoundMixerEnabled_) return -1;
-    if (m_manager == nullptr) return -1;
-    if (sound == nullptr) {
-        Log::GetInstance()->Error(LogCategory::Core, u"SoundMixer::Play: failed, sound is null");
+    RETURN_IF_NULL(sound, -1);
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
         return -1;
     }
-
     return m_manager->Play(sound->GetSound().get());
 }
 
 bool SoundMixer::GetIsPlaying(int32_t id) {
-    if (!isSoundMixerEnabled_) return false;
-    if (m_manager == nullptr) return false;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return false;
+    }
     return m_manager->IsPlaying(id);
 }
 
 void SoundMixer::StopAll() {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->StopAll();
 }
 
 void SoundMixer::Stop(int32_t id) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->Stop(id);
 }
 
 void SoundMixer::Pause(int32_t id) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->Pause(id);
 }
 
 void SoundMixer::Resume(int32_t id) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->Resume(id);
 }
 
 void SoundMixer::SetVolume(int32_t id, float volume) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->SetVolume(id, volume);
 }
 
 void SoundMixer::FadeIn(int32_t id, float second) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->FadeIn(id, second);
 }
 
 void SoundMixer::FadeOut(int32_t id, float second) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->FadeOut(id, second);
 }
 
 void SoundMixer::Fade(int32_t id, float second, float targetedVolume) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->Fade(id, second, targetedVolume);
 }
 
 bool SoundMixer::GetIsPlaybackSpeedEnabled(int32_t id) {
-    if (!isSoundMixerEnabled_) return false;
-    if (m_manager == nullptr) return false;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return false;
+    }
     return m_manager->GetIsPlaybackSpeedEnabled(id);
 }
 
 void SoundMixer::SetIsPlaybackSpeedEnabled(int32_t id, bool isPlaybackSpeedEnabled) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     m_manager->SetIsPlaybackSpeedEnabled(id, isPlaybackSpeedEnabled);
 }
 
 float SoundMixer::GetPlaybackSpeed(int32_t id) {
-    if (!isSoundMixerEnabled_) return 1.0f;
-    if (m_manager == nullptr) return 1.0f;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return 1.0f;
+    }
     return m_manager->GetPlaybackSpeed(id);
 }
 
 void SoundMixer::SetPlaybackSpeed(int32_t id, float playbackSpeed) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     m_manager->SetPlaybackSpeed(id, playbackSpeed);
 }
 
 float SoundMixer::GetPanningPosition(int32_t id) {
-    if (!isSoundMixerEnabled_) return 0.0f;
-    if (m_manager == nullptr) return 0.0f;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return 0.0f;
+    }
     return m_manager->GetPanningPosition(id);
 }
 
 void SoundMixer::SetPanningPosition(int32_t id, float panningPosition) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     m_manager->SetPanningPosition(id, panningPosition);
 }
 
 float SoundMixer::GetPlaybackPosition(int32_t id) {
-    if (!isSoundMixerEnabled_) return 0.0f;
-    if (m_manager == nullptr) return 0.0f;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return 0.0f;
+    }
     return m_manager->GetPlaybackPosition(id);
 }
 
 void SoundMixer::SetPlaybackPosition(int32_t id, float position) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     return m_manager->SetPlaybackPosition(id, position);
 }
 
 void SoundMixer::GetSpectrum(int32_t id, std::shared_ptr<FloatArray>& spectrums, FFTWindow window) {
-    if (!isSoundMixerEnabled_) return;
-    if (m_manager == nullptr) return;
+    if (m_manager == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     m_manager->GetSpectrum(id, spectrums->GetVector(), window);
 }
 
 void SoundMixer::Reload() {
+    if (m_resources == nullptr) {
+        Log::GetInstance()->Error(LogCategory::Core, u"Sound is not enabled.");
+        return;
+    }
     auto container = m_resources->GetResourceContainer(ResourceType::Sound);
     for (auto sound : container->GetAllResouces()) sound.second->Reload(0);
 }

--- a/core/src/Sound/SoundMixer.h
+++ b/core/src/Sound/SoundMixer.h
@@ -27,8 +27,6 @@ class SoundMixer : public BaseObject {
 private:
     static std::shared_ptr<SoundMixer> instance_;
 
-    bool isSoundMixerEnabled_;
-
     std::shared_ptr<osm::Manager> m_manager;
     std::shared_ptr<Resources> m_resources;
 

--- a/core/src/Tool/Tool.cpp
+++ b/core/src/Tool/Tool.cpp
@@ -186,13 +186,13 @@ bool Tool::AddFontFromFileTTF(const char16_t* path, float sizePixels, ToolGlyphR
         io.Fonts->Build();
 
         if (font == nullptr) {
-            Log::GetInstance()->Error(LogCategory::Core, u"Tool::AddFonrFromFileTTF: Failed to load font from '%s'", path_.c_str());
+            Log::GetInstance()->Error(LogCategory::Core, u"Tool::AddFonrFromFileTTF: Failed to load font from '{0}'", path_.c_str());
         }
 
         this_->platform_->CreateFont();
     });
 
-    Log::GetInstance()->Error(LogCategory::Core, u"Tool::AddFonrFromFileTTF: Failed to load font from '%s'", path_.c_str());
+    Log::GetInstance()->Error(LogCategory::Core, u"Tool::AddFonrFromFileTTF: Failed to load font from '{0}'", path_.c_str());
 
     return true;
 }

--- a/core/test/BaseObject.cpp
+++ b/core/test/BaseObject.cpp
@@ -4,10 +4,11 @@
 
 #include <thread>
 
+#include "TestHelper.h"
+
 TEST(BaseObject, Basic) {
-    auto config = Altseed2::Configuration::Create();
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::None);
     EXPECT_TRUE(config != nullptr);
-    config->SetConsoleLoggingEnabled(true);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
     auto defaultObjectCount = Altseed2::Core::GetInstance()->GetBaseObjectCount();
@@ -33,7 +34,9 @@ TEST(BaseObject, Basic) {
 }
 
 TEST(BaseObject, Async) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::None);
+    EXPECT_TRUE(config != nullptr);
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     auto baseObject = new Altseed2::BaseObject();
 
@@ -67,7 +70,9 @@ TEST(BaseObject, Async) {
 }
 
 TEST(BaseObject, DisposeInOtherThreadAfterTerminate) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::None);
+    EXPECT_TRUE(config != nullptr);
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     auto baseObject = new Altseed2::BaseObject();
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -3,6 +3,8 @@ enable_language(CXX)
 
 # set files
 set(core_test_files
+    TestHelper.h
+    TestHelper.cpp
     BaseObject.cpp
     Configuration.cpp
     FPS.cpp

--- a/core/test/Configuration.cpp
+++ b/core/test/Configuration.cpp
@@ -6,6 +6,8 @@
 #include <Graphics/Renderer/Renderer.h>
 #include <gtest/gtest.h>
 
+#include "TestHelper.h"
+
 TEST(Configuration, Initialize) {
     auto config = Altseed2::Configuration::Create();
     EXPECT_EQ(config->GetIsFullscreen(), false);
@@ -15,7 +17,7 @@ TEST(Configuration, Initialize) {
     EXPECT_EQ(config->GetEnabledCoreModules(), Altseed2::CoreModules::Default);
     EXPECT_EQ(std::u16string(config->GetLogFileName()), u"Log.txt");
 
-    auto coreModuels = Altseed2::CoreModules::Default | Altseed2::CoreModules::Tool;
+    auto coreModuels = Altseed2::CoreModules::Graphics;
 
     //config->SetIsFullscreen(true);
     config->SetIsResizable(true);
@@ -37,11 +39,8 @@ TEST(Configuration, Initialize) {
 }
 
 TEST(Configuration, GraphicsOnly) {
-    auto config = Altseed2::Configuration::Create();
-
-    config->SetEnabledCoreModules(Altseed2::CoreModules::Graphics);
-
-    EXPECT_EQ(config->GetEnabledCoreModules(), Altseed2::CoreModules::Graphics);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 

--- a/core/test/Core.cpp
+++ b/core/test/Core.cpp
@@ -1,7 +1,13 @@
 ﻿#include <Core.h>
 #include <gtest/gtest.h>
 
+#include "TestHelper.h"
+
 TEST(Core, Initialize) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto coreModules = Altseed2::CoreModules::Window | Altseed2::CoreModules::File | Altseed2::CoreModules::Keyboard | Altseed2::CoreModules::Mouse | Altseed2::CoreModules::Joystick | Altseed2::CoreModules::Joystick | Altseed2::CoreModules::Graphics;
+    auto config = Altseed2TestConfig(coreModules);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
     Altseed2::Core::Terminate();
 }

--- a/core/test/FPS.cpp
+++ b/core/test/FPS.cpp
@@ -4,8 +4,13 @@
 #include <Logger/Log.h>
 #include <gtest/gtest.h>
 
+#include "TestHelper.h"
+
 TEST(FPS, Update) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::None);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     auto instance = Altseed2::Core::GetInstance();
 
@@ -51,7 +56,10 @@ TEST(FPS, Update) {
 }
 
 TEST(FPS, WithGraphics) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     auto instance = Altseed2::Core::GetInstance();
 

--- a/core/test/File.cpp
+++ b/core/test/File.cpp
@@ -8,8 +8,13 @@
 #include <thread>
 #include <vector>
 
+#include "TestHelper.h"
+
 TEST(File, FileRoot) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::File);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO/pack/", u"TestData/IO/pack.pack"));
@@ -62,7 +67,10 @@ TEST(File, FileRoot) {
 }
 
 TEST(File, StaticFile) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::File);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO", u"TestData/IO/pack.pack"));
@@ -110,7 +118,10 @@ TEST(File, StaticFile) {
 }
 
 TEST(File, StreamFile) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::File);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO/", u"TestData/IO/pack.pack"));
@@ -174,7 +185,10 @@ TEST(File, StreamFile) {
 }
 
 TEST(File, Zenkaku) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::File);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO/", u"TestData/IO/pack.pack"));
@@ -206,7 +220,10 @@ TEST(File, Zenkaku) {
 }
 
 TEST(File, StaticFileAsync) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::File);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO/", u"TestData/IO/pack.pack"));

--- a/core/test/Font.cpp
+++ b/core/test/Font.cpp
@@ -16,10 +16,14 @@
 #include "Graphics/Renderer/RenderedText.h"
 #include "Graphics/Renderer/Renderer.h"
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
+#include "TestHelper.h"
 #include "Tool/Tool.h"
 
 TEST(Font, Basic) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 100);
 
@@ -66,7 +70,10 @@ TEST(Font, Basic) {
 }
 
 TEST(Font, Weight) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 100);
 
@@ -181,7 +188,10 @@ TEST(Font, Weight) {
 // }
 
 TEST(Font, Surrogate) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font = Altseed2::Font::LoadDynamicFont(u"TestData/Font/GenYoMinJP-Bold.ttf", 100);
 
@@ -228,7 +238,10 @@ TEST(Font, Surrogate) {
 }
 
 TEST(Font, ImageFont) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 1280, 720, config));
 
     int count = 0;
 
@@ -279,7 +292,10 @@ TEST(Font, ImageFont) {
 }
 
 TEST(Font, StaticFont) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     EXPECT_TRUE(
             Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/test.a2f", 100, u"Hello, world! こんにちは"));
@@ -338,7 +354,10 @@ TEST(Font, StaticFont) {
 }
 
 TEST(Font, FontSize) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font10 = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 10);
     auto font20 = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 20);
@@ -422,7 +441,10 @@ TEST(Font, FontSize) {
 }
 
 TEST(Font, Return) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 30);
 
@@ -471,7 +493,10 @@ TEST(Font, Return) {
 }
 
 TEST(Font, Vertical) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 30);
 

--- a/core/test/Graphics.cpp
+++ b/core/test/Graphics.cpp
@@ -24,10 +24,14 @@
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
 #include "Logger/Log.h"
 #include "Math/Matrix44F.h"
+#include "TestHelper.h"
 #include "Tool/Tool.h"
 
 TEST(Graphics, Initialize) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"Initialize", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Initialize", 1280, 720, config));
 
     int count = 0;
 
@@ -47,7 +51,10 @@ TEST(Graphics, Initialize) {
 }
 
 TEST(Graphics, Shader) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"Initialize", 800, 600, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Initialize", 800, 600, config));
 
     auto shader = Altseed2::Graphics::GetInstance()->GetBuiltinShader()->Create(Altseed2::BuiltinShaderType::SpriteUnlitPS);
 
@@ -61,7 +68,10 @@ TEST(Graphics, Shader) {
 }
 
 TEST(Graphics, SpriteTexture) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"SpriteTexture", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"SpriteTexture", 1280, 720, config));
 
     int count = 0;
 
@@ -116,7 +126,10 @@ TEST(Graphics, SpriteTexture) {
 }
 
 TEST(Graphics, RenderedText) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedText", 1280, 720, config));
 
     auto font = Altseed2::Font::LoadDynamicFont(u"TestData/Font/mplus-1m-regular.ttf", 100);
 
@@ -229,7 +242,10 @@ TEST(Graphics, RenderedText) {
 }
 
 TEST(Graphics, RenderedPolygon) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedPolygon", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderedPolygon", 1280, 720, config));
 
     int count = 0;
 
@@ -281,8 +297,8 @@ TEST(Graphics, RenderedPolygon) {
 }
 
 TEST(Graphics, AlphaBlend) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
     config->SetFileLoggingEnabled(true);
     EXPECT_TRUE(Altseed2::Core::Initialize(u"AlphaBlend", 1280, 720, config));
 
@@ -346,7 +362,10 @@ TEST(Graphics, AlphaBlend) {
 }
 
 TEST(Graphics, CameraBasic) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"CameraBasic", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"CameraBasic", 1280, 720, config));
 
     int count = 0;
 
@@ -411,9 +430,10 @@ TEST(Graphics, CameraBasic) {
 }
 
 TEST(Graphics, RenderTexture) {
-    auto config = Altseed2::Configuration::Create();
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
     config->SetFileLoggingEnabled(true);
-    config->SetConsoleLoggingEnabled(true);
     config->SetLogFileName(u"RenderTexture.txt");
     EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderTexture", 1280, 720, config));
     Altseed2::Log::GetInstance()->SetLevel(Altseed2::LogCategory::Graphics, Altseed2::LogLevel::Trace);
@@ -490,9 +510,10 @@ TEST(Graphics, RenderTexture) {
 }
 
 TEST(Graphics, RenderTextureSave) {
-    auto config = Altseed2::Configuration::Create();
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
     config->SetFileLoggingEnabled(true);
-    config->SetConsoleLoggingEnabled(true);
     config->SetLogFileName(u"RenderTextureSave.txt");
     EXPECT_TRUE(Altseed2::Core::Initialize(u"RenderTextureSave", 1280, 720, config));
     Altseed2::Log::GetInstance()->SetLevel(Altseed2::LogCategory::Graphics, Altseed2::LogLevel::Trace);
@@ -570,7 +591,10 @@ TEST(Graphics, RenderTextureSave) {
 }
 
 TEST(Graphics, BackgroundBugcheck) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"SpriteTexture", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"SpriteTexture", 1280, 720, config));
 
     int count = 0;
 
@@ -693,7 +717,10 @@ VS_OUTPUT main(VS_INPUT input){
 }
 )";
 
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"VertexTextureFetch", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"VertexTextureFetch", 1280, 720, config));
 
     int count = 0;
 
@@ -742,7 +769,10 @@ VS_OUTPUT main(VS_INPUT input){
 }
 
 TEST(Graphics, Culling) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"Culling", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Culling", 1280, 720, config));
 
     int count = 0;
 
@@ -801,7 +831,10 @@ TEST(Graphics, Culling) {
 }
 
 TEST(Graphics, CullingTooManySprite) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"SpriteTexture", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"SpriteTexture", 1280, 720, config));
 
     int count = 0;
 
@@ -882,8 +915,8 @@ TEST(Graphics, CullingTooManySprite) {
 }
 
 TEST(Graphics, RenderToRenderTexture) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"RnderToRenderTexture", 1280, 720, config));
 
@@ -961,7 +994,10 @@ float4 main(PS_INPUT input) : SV_TARGET
 }
 )";
 
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"TextureWrapMode", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"TextureWrapMode", 1280, 720, config));
 
     auto instance = Altseed2::Graphics::GetInstance();
 
@@ -1008,7 +1044,10 @@ float4 main(PS_INPUT input) : SV_TARGET
 }
 
 TEST(Graphics, ShaderFromFile) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"ShaderFromFile", 1280, 720, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"ShaderFromFile", 1280, 720, config));
 
     auto instance = Altseed2::Graphics::GetInstance();
 
@@ -1073,8 +1112,8 @@ float4 main(PS_INPUT input) : SV_TARGET
 }
 )";
 
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"ScreenTextureFormat", 1280, 720, config));
 

--- a/core/test/Joystick.cpp
+++ b/core/test/Joystick.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <cmath>
 
+#include "TestHelper.h"
+
 bool IsPushedOrHolded(int joystickIndex, Altseed2::JoystickButton btn, int count) {
     if (Altseed2::Joystick::GetInstance()->GetButtonStateByType(joystickIndex, btn) == Altseed2::ButtonState::Free ||
         Altseed2::Joystick::GetInstance()->GetButtonStateByType(joystickIndex, btn) == Altseed2::ButtonState::Release) {
@@ -103,8 +105,8 @@ void printJoystickInformation() {
 }
 
 TEST(Joystick, Initialize) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Joystick);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"Joystick Initialize", 640, 480, config));
 
@@ -120,8 +122,8 @@ TEST(Joystick, Initialize) {
 }
 
 TEST(Joystick, ButtonState) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Joystick);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"Joystick ButtonState", 640, 480, config));
 
@@ -162,8 +164,8 @@ TEST(Joystick, ButtonState) {
 }
 
 TEST(Joystick, AxisState) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Joystick);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"Joystick AxisState", 640, 480, config));
 
@@ -217,8 +219,8 @@ TEST(Joystick, ButtonStateByType) {
             {std::string("DPadLeft"), Altseed2::JoystickButton::DPadLeft},
     };
 
-    auto config = Altseed2::Configuration::Create();
-    // config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Joystick);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"Joystick ButtonStateByType", 640, 480, config));
 
@@ -263,7 +265,8 @@ TEST(Joystick, AxisStateByType) {
             {std::string("RightY"), Altseed2::JoystickAxis::RightY},
     };
 
-    auto config = Altseed2::Configuration::Create();
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Joystick);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"Joystick ButtonStateByType", 640, 480, config));
 

--- a/core/test/Keyboard.cpp
+++ b/core/test/Keyboard.cpp
@@ -3,6 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <string>
+
+#include "TestHelper.h"
+
 #define STR(var) #var
 
 using namespace std::string_literals;
@@ -29,9 +32,10 @@ TEST(Keyboard, Initialize) {
 */
 
 TEST(Keyboard, GetKeyState) {
-    char16_t s16[] = u"test";
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Keyboard);
+    EXPECT_TRUE(config != nullptr);
 
-    EXPECT_TRUE(Altseed2::Core::Initialize(s16, 640, 480, Altseed2::Configuration::Create()));
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Keyboard", 640, 480, config));
 
     for (int count = 0; Altseed2::Core::GetInstance()->DoEvent() && count < 60; count++) {
         for (int i = 0; i < static_cast<int>(Altseed2::Key::MAX); i++) {

--- a/core/test/Mouse.cpp
+++ b/core/test/Mouse.cpp
@@ -3,14 +3,18 @@
 #include <gtest/gtest.h>
 
 #include <string>
+
+#include "TestHelper.h"
+
 #define STR(var) #var
 
 using namespace std::string_literals;
 
 TEST(Mouse, Initialize) {
-    char16_t s16[] = u"Mouse";
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Mouse | Altseed2::CoreModules::File);
+    EXPECT_TRUE(config != nullptr);
 
-    EXPECT_TRUE(Altseed2::Core::Initialize(s16, 640, 480, Altseed2::Configuration::Create()));
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Mouse", 640, 480, Altseed2::Configuration::Create()));
 
     int i = 0;
 
@@ -38,9 +42,10 @@ void WheelTestFunction(double x, double y) {
 }
 
 TEST(Mouse, GetMouseInput) {
-    char16_t s16[] = u"Mouse inputs";
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Mouse);
+    EXPECT_TRUE(config != nullptr);
 
-    EXPECT_TRUE(Altseed2::Core::Initialize(s16, 640, 480, Altseed2::Configuration::Create()));
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Mouse inputs", 640, 480, Altseed2::Configuration::Create()));
 
     Altseed2::Mouse::GetInstance()->Altseed2::Mouse::SetWheelCallback(WheelTestFunction);
 
@@ -75,9 +80,10 @@ TEST(Mouse, GetMouseInput) {
 }
 
 TEST(Mouse, Position) {
-    char16_t s16[] = u"Mouse position";
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Mouse);
+    EXPECT_TRUE(config != nullptr);
 
-    EXPECT_TRUE(Altseed2::Core::Initialize(s16, 640, 480, Altseed2::Configuration::Create()));
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"Mouse position", 640, 480, Altseed2::Configuration::Create()));
 
     Altseed2::Mouse::GetInstance()->SetPosition(Altseed2::Vector2F(320, 240));
     Altseed2::Vector2F result = Altseed2::Mouse::GetInstance()->GetPosition();

--- a/core/test/PostEffect.cpp
+++ b/core/test/PostEffect.cpp
@@ -20,6 +20,7 @@
 #include "Graphics/Shader.h"
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
 #include "Logger/Log.h"
+#include "TestHelper.h"
 
 TEST(PostEffect, Base) {
     const char* PostEffectCode = R"(
@@ -50,8 +51,8 @@ TEST(PostEffect, Base) {
     }
     )";
 
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"PostEffectBase", 1280, 720, config));
 
@@ -104,8 +105,8 @@ TEST(PostEffect, Base) {
 }
 
 TEST(PostEffect, Builtin) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"PostEffect Builtin", 400, 300, config));
 
@@ -170,8 +171,8 @@ TEST(PostEffect, Builtin) {
 }
 
 TEST(PostEffect, Sepia) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"PostEffect Sepia", 1280, 720, config));
 
@@ -227,8 +228,8 @@ TEST(PostEffect, Sepia) {
 }
 
 TEST(PostEffect, GrayScale) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"PostEffect GrayScale", 1280, 720, config));
 
@@ -284,8 +285,8 @@ TEST(PostEffect, GrayScale) {
 }
 
 TEST(PostEffect, GaussianBlur) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"PostEffect LightBloom", 1280, 720, config));
 
@@ -381,8 +382,8 @@ TEST(PostEffect, GaussianBlur) {
 }
 
 TEST(PostEffect, LightBloom) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetConsoleLoggingEnabled(true);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"PostEffect LightBloom", 1280, 720, config));
 

--- a/core/test/Sound.cpp
+++ b/core/test/Sound.cpp
@@ -2,18 +2,26 @@
 #include <Sound/SoundMixer.h>
 #include <gtest/gtest.h>
 
+#include "TestHelper.h"
+
 namespace asd = Altseed2;
 
 TEST(Sound, SoundPlay) {
-    char16_t s16[] = u"Sound Play";
-    EXPECT_TRUE(asd::Core::Initialize(s16, 640, 480, asd::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Sound);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(asd::Core::Initialize(u"Sound Play", 640, 480, config));
 
     auto bgm = asd::Sound::Load(u"TestData/Sound/bgm1.ogg", false);
+    EXPECT_TRUE(bgm != nullptr);
     auto se = asd::Sound::Load(u"TestData/Sound/se1.wav", true);
+    EXPECT_TRUE(se != nullptr);
 
     auto mixer = asd::SoundMixer::GetInstance();
     int id_bgm = mixer->Play(bgm);
+    EXPECT_TRUE(id_bgm != -1);
     int id_se = mixer->Play(se);
+    EXPECT_TRUE(id_se != -1);
 
     clock_t start = clock();
 
@@ -27,23 +35,24 @@ TEST(Sound, SoundPlay) {
 }
 
 TEST(Sound, SoundLoop) {
-    char16_t s16[] = u"Sound Loop";
-    EXPECT_TRUE(asd::Core::Initialize(s16, 640, 480, asd::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Sound);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(asd::Core::Initialize(u"Sound Loop", 640, 480, config));
 
     auto bgm = asd::Sound::Load(u"TestData/Sound/bgm1.ogg", false);
+    EXPECT_TRUE(bgm != nullptr);
 
     auto mixer = asd::SoundMixer::GetInstance();
-    int id_bgm = -1;
 
-    if (bgm != nullptr) {
-        EXPECT_FALSE(bgm->GetIsLoopingMode());
-        bgm->SetIsLoopingMode(true);
-        EXPECT_TRUE(bgm->GetIsLoopingMode());
-        bgm->SetLoopStartingPoint(1.0);
-        bgm->SetLoopEndPoint(2.5);
+    EXPECT_FALSE(bgm->GetIsLoopingMode());
+    bgm->SetIsLoopingMode(true);
+    EXPECT_TRUE(bgm->GetIsLoopingMode());
+    bgm->SetLoopStartingPoint(1.0);
+    bgm->SetLoopEndPoint(2.5);
 
-        id_bgm = mixer->Play(bgm);
-    }
+    int id_bgm = mixer->Play(bgm);
+    EXPECT_TRUE(id_bgm != -1);
 
     clock_t start = clock();
 
@@ -57,15 +66,18 @@ TEST(Sound, SoundLoop) {
 }
 
 TEST(Sound, SoundResume) {
-    char16_t s16[] = u"Sound Resume";
-    EXPECT_TRUE(asd::Core::Initialize(s16, 640, 480, asd::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Sound);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(asd::Core::Initialize(u"SOund Resume", 640, 480, config));
 
     auto bgm = asd::Sound::Load(u"TestData/Sound/bgm1.ogg", false);
+    EXPECT_TRUE(bgm != nullptr);
 
     auto mixer = asd::SoundMixer::GetInstance();
-    int id_bgm = -1;
 
-    if (bgm != nullptr) id_bgm = mixer->Play(bgm);
+    int id_bgm = mixer->Play(bgm);
+    EXPECT_TRUE(id_bgm != -1);
 
     clock_t start = clock();
     int stage = 0;
@@ -99,38 +111,44 @@ TEST(Sound, SoundResume) {
 }
 
 TEST(Sound, SoundLength) {
-    char16_t s16[] = u"Sound Length";
-    EXPECT_TRUE(asd::Core::Initialize(s16, 640, 480, asd::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Sound);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(asd::Core::Initialize(u"Sound Length", 640, 480, config));
 
     auto bgm = asd::Sound::Load(u"TestData/Sound/bgm1.ogg", false);
+    EXPECT_TRUE(bgm != nullptr);
     auto se = asd::Sound::Load(u"TestData/Sound/se1.wav", true);
+    EXPECT_TRUE(se != nullptr);
 
     auto mixer = asd::SoundMixer::GetInstance();
-    int id_bgm = -1, id_se = -1;
 
-    if (bgm != nullptr) {
-        id_bgm = mixer->Play(bgm);
-        id_se = mixer->Play(se);
+    int id_bgm = mixer->Play(bgm);
+    EXPECT_TRUE(id_bgm != -1);
+    int id_se = mixer->Play(se);
+    EXPECT_TRUE(id_se != -1);
 
-        printf("Length of bgm : %f [sec]\n", bgm->GetLength());
-        printf("Length of se  : %f [sec]\n", se->GetLength());
-    }
+    printf("Length of bgm : %f [sec]\n", bgm->GetLength());
+    printf("Length of se  : %f [sec]\n", se->GetLength());
 
     asd::Core::Terminate();
 }
 
 TEST(Sound, SpectrumAnalyze) {
-    char16_t s16[] = u"Spectrum Analyze";
-    EXPECT_TRUE(asd::Core::Initialize(s16, 640, 480, asd::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Sound);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(asd::Core::Initialize(u"Spectrum Analyze", 640, 480, config));
 
     auto bgm = asd::Sound::Load(u"TestData/Sound/bgm1.ogg", false);
+    EXPECT_TRUE(bgm != nullptr);
 
     auto spectrumData = asd::MakeAsdShared<asd::FloatArray>(8192);
 
     auto mixer = asd::SoundMixer::GetInstance();
-    int id_bgm = -1;
 
-    if (bgm != nullptr) id_bgm = mixer->Play(bgm);
+    int id_bgm = mixer->Play(bgm);
+    EXPECT_TRUE(id_bgm != -1);
 
     clock_t start = clock();
 

--- a/core/test/TestHelper.cpp
+++ b/core/test/TestHelper.cpp
@@ -1,0 +1,9 @@
+#include "TestHelper.h"
+
+std::shared_ptr<Altseed2::Configuration> Altseed2TestConfig(Altseed2::CoreModules coreModules) {
+    auto config = Altseed2::Configuration::Create();
+    if (config == nullptr) return nullptr;
+    config->SetConsoleLoggingEnabled(true);
+    config->SetEnabledCoreModules(coreModules);
+    return config;
+}

--- a/core/test/TestHelper.h
+++ b/core/test/TestHelper.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <Configuration.h>
+
+std::shared_ptr<Altseed2::Configuration> Altseed2TestConfig(Altseed2::CoreModules coreModules);

--- a/core/test/Texture2D.cpp
+++ b/core/test/Texture2D.cpp
@@ -12,9 +12,12 @@
 #include "Graphics/Renderer/RenderedSprite.h"
 #include "Graphics/Renderer/Renderer.h"
 #include "Logger/Log.h"
+#include "TestHelper.h"
 
 TEST(Texture2D, Base) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO/", u"TestData/IO/pack.pack"));
@@ -52,7 +55,10 @@ TEST(Texture2D, Base) {
 }
 
 TEST(Texture2D, Async) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     // pack files
     EXPECT_TRUE(Altseed2::File::GetInstance()->Pack(u"TestData/IO/", u"TestData/IO/pack.pack"));
@@ -102,7 +108,10 @@ TEST(Texture2D, Async) {
 }
 
 TEST(Texture2D, Save) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     auto instance = Altseed2::Graphics::GetInstance();
 
@@ -156,7 +165,9 @@ void* Texture2D_Cache_Func(const char16_t* path) {
 }
 
 TEST(Texture2D, Cache) {
-    auto config = Altseed2::Configuration::Create();
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
     config->SetFileLoggingEnabled(true);
     config->SetLogFileName(u"cache.txt");
     EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));

--- a/core/test/Tool.cpp
+++ b/core/test/Tool.cpp
@@ -17,6 +17,7 @@
 #include "Math/Matrix44F.h"
 #include "Math/RectF.h"
 #include "System/SynchronizationContext.h"
+#include "TestHelper.h"
 
 #if !defined(_WIN32) || defined(_WIN64)
 
@@ -32,8 +33,8 @@ std::u16string format(const std::u16string& fmt, Args... args) {
 }
 
 static void ToolTestTemplate(const int loopCount, std::function<void(std::shared_ptr<Altseed2::Tool>)> update) {
-    auto config = Altseed2::Configuration::Create();
-    config->SetEnabledCoreModules(Altseed2::CoreModules::Default | Altseed2::CoreModules::Tool);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics | Altseed2::CoreModules::Tool);
+    EXPECT_TRUE(config != nullptr);
 
     EXPECT_TRUE(Altseed2::Core::Initialize(u"Tool", 1280, 720, config));
 
@@ -553,8 +554,7 @@ TEST(Tool, Popup) {
 TEST(Tool, SaveDialog) {
     return;
 
-    auto config = Altseed2::Configuration::Create();
-    config->SetEnabledCoreModules(Altseed2::CoreModules::Default | Altseed2::CoreModules::Tool);
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics | Altseed2::CoreModules::Tool);
     EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
 
     Altseed2::Tool::GetInstance()->OpenDialog(u"png;jpg,jpeg", u"");

--- a/core/test/Window.cpp
+++ b/core/test/Window.cpp
@@ -4,8 +4,11 @@
 
 #include <string>
 
+#include "TestHelper.h"
+
 TEST(Window, Base) {
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 150, 150, Altseed2::Configuration::Create()));
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Window);
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 150, 150, config));
 
     int i = 0;
     while (Altseed2::Window::GetInstance()->DoEvent() && i < 16) {


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
CoreModuleの変更に関して、Core::DoEventの修正。
nullcheckが漏れてたのも修正

 ~Sound初期化失敗時に握り潰すのではなく、正しくfalseを返す。~
これは元に戻しました(bool値ではなく、失敗したらm_managerにnullptrをsetするようにした)

これに関して、CIではgtest_filterでSoundのテストを実行しないようにする。
また、他のテストでは必要最低限の機能だけを有効化する。

全てのTestにConsoleLoggingをenableにしたところ `Tool::AddFontFromFileTTF` のlog出力形式が誤っていたので修正。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->

