### PR TITLE
GenerateFontFileで出力先のディレクトリが存在しない場合のlogを追加しました

### DIFF
--- a/core/src/AutoGeneratedCoreWrapper.cpp
+++ b/core/src/AutoGeneratedCoreWrapper.cpp
@@ -33,6 +33,7 @@
 #endif
 #endif
 
+
 #include "BaseObject.h"
 #include "Common/Array.h"
 #include "Common/Resource.h"
@@ -44,13 +45,13 @@
 #include "Graphics/Font.h"
 #include "Graphics/Graphics.h"
 #include "Graphics/ImageFont.h"
-#include "Graphics/RenderTexture.h"
-#include "Graphics/Renderer/RenderedCamera.h"
-#include "Graphics/Renderer/RenderedIBPolygon.h"
-#include "Graphics/Renderer/RenderedPolygon.h"
-#include "Graphics/Renderer/RenderedSprite.h"
 #include "Graphics/Renderer/RenderedText.h"
+#include "Graphics/Renderer/RenderedCamera.h"
+#include "Graphics/Renderer/RenderedSprite.h"
+#include "Graphics/Renderer/RenderedPolygon.h"
+#include "Graphics/Renderer/RenderedIBPolygon.h"
 #include "Graphics/Renderer/Renderer.h"
+#include "Graphics/RenderTexture.h"
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
 #include "Graphics/Texture2D.h"
 #include "IO/BaseFileReader.h"
@@ -65,15 +66,15 @@
 #include "Input/Keyboard.h"
 #include "Input/Mouse.h"
 #include "Logger/Log.h"
-#include "Physics/Collider/CircleCollider.h"
 #include "Physics/Collider/Collider.h"
+#include "Physics/Collider/CircleCollider.h"
 #include "Physics/Collider/PolygonCollider.h"
 #include "Physics/Collider/RectangleCollider.h"
 #include "Sound/Sound.h"
 #include "Sound/SoundMixer.h"
 #include "Tool/Tool.h"
 #include "Window/Window.h"
-
+    
 extern "C" {
 
 CBGEXPORT void* CBGSTDCALL cbg_Configuration_Create() {
@@ -2295,7 +2296,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_Button(void* cbg_self, const char16_t* label,
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_CheckBox(void* cbg_self, const char16_t* label, bool* isChecked) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_CheckBox(void* cbg_self, const char16_t* label, bool * isChecked) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2313,7 +2314,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton_2(void* cbg_self, const char16_t* label, int32_t* v, int32_t v_button) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton_2(void* cbg_self, const char16_t* label, int32_t * v, int32_t v_button) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2341,7 +2342,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InvisibleButton(void* cbg_self, const char16_
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t* current, const char16_t* items, int32_t popupMaxHeightInItems) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t * current, const char16_t* items, int32_t popupMaxHeightInItems) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2352,7 +2353,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* label, bool* selected, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* label, bool * selected, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2397,7 +2398,7 @@ CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextMultiline(void* cbg_self,
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt(void* cbg_self, const char16_t* label, int32_t* value) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt(void* cbg_self, const char16_t* label, int32_t * value) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2433,7 +2434,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt4(void* cbg_self, const char16_t* lab
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat(void* cbg_self, const char16_t* label, float* value) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat(void* cbg_self, const char16_t* label, float * value) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2469,7 +2470,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat4(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t* value, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t * value, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2517,7 +2518,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt4(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float* value, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float * value, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2565,7 +2566,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat4(void* cbg_self, const char16_t* 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* label, float* angle) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* label, float * angle) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2574,7 +2575,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, int32_t* value, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, int32_t * value, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2586,7 +2587,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, float* value, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, float * value, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2598,7 +2599,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t* value, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t * value, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2610,7 +2611,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float* value, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float * value, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2622,7 +2623,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* lab
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t* label, int32_t* currentMin, int32_t* currentMax, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t* label, int32_t * currentMin, int32_t * currentMax, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2635,7 +2636,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t*
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_t* label, float* currentMin, float* currentMax, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_t* label, float * currentMin, float * currentMax, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2648,7 +2649,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* label, Altseed2::Color_C* color, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* label, Altseed2::Color_C * color, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2658,7 +2659,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit4(void* cbg_self, const char16_t* label, Altseed2::Color_C* color, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit4(void* cbg_self, const char16_t* label, Altseed2::Color_C * color, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3458,7 +3459,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_EndCombo(void* cbg_self) {
     cbg_self_->EndCombo();
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t* current_item, const char16_t* items, int32_t popupMaxHeightInItems) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t * current_item, const char16_t* items, int32_t popupMaxHeightInItems) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3469,7 +3470,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorButton(void* cbg_self, const char16_t* descId, Altseed2::Color_C* col, int32_t flags, Altseed2::Vector2F_C size) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorButton(void* cbg_self, const char16_t* descId, Altseed2::Color_C * col, int32_t flags, Altseed2::Vector2F_C size) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = descId;
@@ -3605,7 +3606,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupContextVoid(void* cbg_self, const c
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupModalEx(void* cbg_self, const char16_t* name, bool* isOpen, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupModalEx(void* cbg_self, const char16_t* name, bool * isOpen, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = name;
@@ -4610,4 +4611,7 @@ CBGEXPORT void CBGSTDCALL cbg_PolygonCollider_Release(void* cbg_self) {
 
     cbg_self_->Release();
 }
+
+
 }
+

--- a/core/src/AutoGeneratedCoreWrapper.cpp
+++ b/core/src/AutoGeneratedCoreWrapper.cpp
@@ -33,7 +33,6 @@
 #endif
 #endif
 
-
 #include "BaseObject.h"
 #include "Common/Array.h"
 #include "Common/Resource.h"
@@ -45,13 +44,13 @@
 #include "Graphics/Font.h"
 #include "Graphics/Graphics.h"
 #include "Graphics/ImageFont.h"
-#include "Graphics/Renderer/RenderedText.h"
-#include "Graphics/Renderer/RenderedCamera.h"
-#include "Graphics/Renderer/RenderedSprite.h"
-#include "Graphics/Renderer/RenderedPolygon.h"
-#include "Graphics/Renderer/RenderedIBPolygon.h"
-#include "Graphics/Renderer/Renderer.h"
 #include "Graphics/RenderTexture.h"
+#include "Graphics/Renderer/RenderedCamera.h"
+#include "Graphics/Renderer/RenderedIBPolygon.h"
+#include "Graphics/Renderer/RenderedPolygon.h"
+#include "Graphics/Renderer/RenderedSprite.h"
+#include "Graphics/Renderer/RenderedText.h"
+#include "Graphics/Renderer/Renderer.h"
 #include "Graphics/ShaderCompiler/ShaderCompiler.h"
 #include "Graphics/Texture2D.h"
 #include "IO/BaseFileReader.h"
@@ -66,15 +65,15 @@
 #include "Input/Keyboard.h"
 #include "Input/Mouse.h"
 #include "Logger/Log.h"
-#include "Physics/Collider/Collider.h"
 #include "Physics/Collider/CircleCollider.h"
+#include "Physics/Collider/Collider.h"
 #include "Physics/Collider/PolygonCollider.h"
 #include "Physics/Collider/RectangleCollider.h"
 #include "Sound/Sound.h"
 #include "Sound/SoundMixer.h"
 #include "Tool/Tool.h"
 #include "Window/Window.h"
-    
+
 extern "C" {
 
 CBGEXPORT void* CBGSTDCALL cbg_Configuration_Create() {
@@ -2296,7 +2295,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_Button(void* cbg_self, const char16_t* label,
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_CheckBox(void* cbg_self, const char16_t* label, bool * isChecked) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_CheckBox(void* cbg_self, const char16_t* label, bool* isChecked) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2314,7 +2313,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton_2(void* cbg_self, const char16_t* label, int32_t * v, int32_t v_button) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_RadioButton_2(void* cbg_self, const char16_t* label, int32_t* v, int32_t v_button) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2342,7 +2341,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InvisibleButton(void* cbg_self, const char16_
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t * current, const char16_t* items, int32_t popupMaxHeightInItems) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label, int32_t* current, const char16_t* items, int32_t popupMaxHeightInItems) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2353,7 +2352,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_ListBox(void* cbg_self, const char16_t* label
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* label, bool * selected, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_Selectable(void* cbg_self, const char16_t* label, bool* selected, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2398,7 +2397,7 @@ CBGEXPORT const char16_t* CBGSTDCALL cbg_Tool_InputTextMultiline(void* cbg_self,
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt(void* cbg_self, const char16_t* label, int32_t * value) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt(void* cbg_self, const char16_t* label, int32_t* value) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2434,7 +2433,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InputInt4(void* cbg_self, const char16_t* lab
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat(void* cbg_self, const char16_t* label, float * value) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat(void* cbg_self, const char16_t* label, float* value) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2470,7 +2469,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_InputFloat4(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t * value, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt(void* cbg_self, const char16_t* label, int32_t* value, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2518,7 +2517,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderInt4(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float * value, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat(void* cbg_self, const char16_t* label, float* value, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2566,7 +2565,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderFloat4(void* cbg_self, const char16_t* 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* label, float * angle) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* label, float* angle) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2575,7 +2574,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_SliderAngle(void* cbg_self, const char16_t* l
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, int32_t * value, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, int32_t* value, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2587,7 +2586,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderInt(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, float * value, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* label, Altseed2::Vector2F_C size, float* value, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2599,7 +2598,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_VSliderFloat(void* cbg_self, const char16_t* 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t * value, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label, int32_t* value, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2611,7 +2610,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragInt(void* cbg_self, const char16_t* label
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float * value, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* label, float* value, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2623,7 +2622,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloat(void* cbg_self, const char16_t* lab
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t* label, int32_t * currentMin, int32_t * currentMax, float speed, int32_t valueMin, int32_t valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t* label, int32_t* currentMin, int32_t* currentMax, float speed, int32_t valueMin, int32_t valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2636,7 +2635,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragIntRange2(void* cbg_self, const char16_t*
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_t* label, float * currentMin, float * currentMax, float speed, float valueMin, float valueMax) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_t* label, float* currentMin, float* currentMax, float speed, float valueMin, float valueMax) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2649,7 +2648,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_DragFloatRange2(void* cbg_self, const char16_
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* label, Altseed2::Color_C * color, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* label, Altseed2::Color_C* color, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -2659,7 +2658,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit3(void* cbg_self, const char16_t* la
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit4(void* cbg_self, const char16_t* label, Altseed2::Color_C * color, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorEdit4(void* cbg_self, const char16_t* label, Altseed2::Color_C* color, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3459,7 +3458,7 @@ CBGEXPORT void CBGSTDCALL cbg_Tool_EndCombo(void* cbg_self) {
     cbg_self_->EndCombo();
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t * current_item, const char16_t* items, int32_t popupMaxHeightInItems) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, int32_t* current_item, const char16_t* items, int32_t popupMaxHeightInItems) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = label;
@@ -3470,7 +3469,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_Combo(void* cbg_self, const char16_t* label, 
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorButton(void* cbg_self, const char16_t* descId, Altseed2::Color_C * col, int32_t flags, Altseed2::Vector2F_C size) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_ColorButton(void* cbg_self, const char16_t* descId, Altseed2::Color_C* col, int32_t flags, Altseed2::Vector2F_C size) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = descId;
@@ -3606,7 +3605,7 @@ CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupContextVoid(void* cbg_self, const c
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupModalEx(void* cbg_self, const char16_t* name, bool * isOpen, int32_t flags) {
+CBGEXPORT bool CBGSTDCALL cbg_Tool_BeginPopupModalEx(void* cbg_self, const char16_t* name, bool* isOpen, int32_t flags) {
     auto cbg_self_ = (Altseed2::Tool*)(cbg_self);
 
     const char16_t* cbg_arg0 = name;
@@ -4611,7 +4610,4 @@ CBGEXPORT void CBGSTDCALL cbg_PolygonCollider_Release(void* cbg_self) {
 
     cbg_self_->Release();
 }
-
-
 }
-

--- a/core/src/Graphics/Font.cpp
+++ b/core/src/Graphics/Font.cpp
@@ -208,7 +208,6 @@ std::shared_ptr<Font> Font::LoadStaticFont(const char16_t* path) {
     return font;
 }
 
-
 std::shared_ptr<Font> Font::CreateImageFont(std::shared_ptr<Font> baseFont) {
     RETURN_IF_NULL(baseFont, nullptr);
     return std::static_pointer_cast<Font>(MakeAsdShared<ImageFont>(baseFont));
@@ -218,11 +217,9 @@ bool Font::GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* sta
     RETURN_IF_NULL(dynamicFontPath, false);
     RETURN_IF_NULL(staticFontPath, false);
     RETURN_IF_NULL(characters, false);
-    
+
     auto parentDir = FileSystem::GetParentPath(staticFontPath);
-    if (!FileSystem::GetIsDirectory(parentDir.c_str()))
-    {
-        
+    if (!FileSystem::GetIsDirectory(parentDir.c_str())) {
         Log::GetInstance()->Error(LogCategory::Core, u"Font::GenerateFontFile: The output directory cannot be accessed.");
         return false;
     }
@@ -303,8 +300,6 @@ bool Font::GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* sta
     writer.WriteOut(fs);
     return true;
 }
-
-
 
 bool Font::Reload() { return false; }
 

--- a/core/src/Graphics/Font.cpp
+++ b/core/src/Graphics/Font.cpp
@@ -208,6 +208,7 @@ std::shared_ptr<Font> Font::LoadStaticFont(const char16_t* path) {
     return font;
 }
 
+
 std::shared_ptr<Font> Font::CreateImageFont(std::shared_ptr<Font> baseFont) {
     RETURN_IF_NULL(baseFont, nullptr);
     return std::static_pointer_cast<Font>(MakeAsdShared<ImageFont>(baseFont));
@@ -221,15 +222,15 @@ bool Font::GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* sta
     auto parentDir = FileSystem::GetParentPath(staticFontPath);
     if (!FileSystem::GetIsDirectory(parentDir.c_str()))
     {
-        // いい感じのlogを吐く
-        Log::GetInstance()->Error(LogCategory::Core, u"The output directory cannot be accessed.");
+        
+        Log::GetInstance()->Error(LogCategory::Core, u"Font::GenerateFontFile: The output directory cannot be accessed.");
         return false;
     }
     BinaryWriter writer;
 
     auto font = Font::LoadDynamicFont(dynamicFontPath, size);
     if (font == nullptr) {
-        Log::GetInstance()->Error(LogCategory::Core, u"Failed to create font");
+        Log::GetInstance()->Error(LogCategory::Core, u"Font::GenerateFontFile: Failed to create font");
         return false;
     }
 
@@ -302,6 +303,8 @@ bool Font::GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* sta
     writer.WriteOut(fs);
     return true;
 }
+
+
 
 bool Font::Reload() { return false; }
 

--- a/core/src/Graphics/Font.cpp
+++ b/core/src/Graphics/Font.cpp
@@ -214,6 +214,17 @@ std::shared_ptr<Font> Font::CreateImageFont(std::shared_ptr<Font> baseFont) {
 }
 
 bool Font::GenerateFontFile(const char16_t* dynamicFontPath, const char16_t* staticFontPath, int32_t size, const char16_t* characters) {
+    RETURN_IF_NULL(dynamicFontPath, false);
+    RETURN_IF_NULL(staticFontPath, false);
+    RETURN_IF_NULL(characters, false);
+    
+    auto parentDir = FileSystem::GetParentPath(staticFontPath);
+    if (!FileSystem::GetIsDirectory(parentDir.c_str()))
+    {
+        // いい感じのlogを吐く
+        Log::GetInstance()->Error(LogCategory::Core, u"The output directory cannot be accessed.");
+        return false;
+    }
     BinaryWriter writer;
 
     auto font = Font::LoadDynamicFont(dynamicFontPath, size);

--- a/core/test/Font.cpp
+++ b/core/test/Font.cpp
@@ -545,7 +545,6 @@ TEST(Font, Vertical) {
     Altseed2::Core::Terminate();
 }
 
-
 TEST(Font, GenerateFontFile) {
     auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
     EXPECT_TRUE(config != nullptr);
@@ -553,7 +552,7 @@ TEST(Font, GenerateFontFile) {
     EXPECT_TRUE(Altseed2::FileSystem::IsDirectory(u"TestData/Font"));
     EXPECT_TRUE(
             Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/test.a2f", 100, u"Hello, world! こんにちは"));
-            
+
     EXPECT_FALSE(Altseed2::FileSystem::IsDirectory(u"TestData/Font/NotExistedDirectory"));
     EXPECT_FALSE(
             Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/NotExistedDirectory/test.a2f", 100, u"Hello, world! こんにちは"));

--- a/core/test/Font.cpp
+++ b/core/test/Font.cpp
@@ -548,13 +548,19 @@ TEST(Font, Vertical) {
 TEST(Font, GenerateFontFile) {
     auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
     EXPECT_TRUE(config != nullptr);
-    EXPECT_TRUE(Altseed2::Core::Initialize(u"GenerateFontFile", 600, 400, config));
-    EXPECT_TRUE(Altseed2::FileSystem::IsDirectory(u"TestData/Font"));
-    EXPECT_TRUE(
-            Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/test.a2f", 100, u"Hello, world! こんにちは"));
 
-    EXPECT_FALSE(Altseed2::FileSystem::IsDirectory(u"TestData/Font/NotExistedDirectory"));
+    const auto filename = u"TestData/Font/mplus-1m-regular.ttf";
+    const auto characters = u"Hello, world! こんにちは";
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"GenerateFontFile", 600, 400, config));
+
+    EXPECT_TRUE(Altseed2::FileSystem::GetIsDirectory(u"TestData/Font"));
+    EXPECT_TRUE(
+            Altseed2::Font::GenerateFontFile(filename, u"TestData/Font/test.a2f", 100, characters));
+
+    EXPECT_FALSE(Altseed2::FileSystem::GetIsDirectory(u"TestData/Font/NotExistedDirectory"));
     EXPECT_FALSE(
-            Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/NotExistedDirectory/test.a2f", 100, u"Hello, world! こんにちは"));
+            Altseed2::Font::GenerateFontFile(filename, u"TestData/Font/NotExistedDirectory/test.a2f", 100, characters));
+
     Altseed2::Core::Terminate();
 }

--- a/core/test/Font.cpp
+++ b/core/test/Font.cpp
@@ -550,8 +550,11 @@ TEST(Font, GenerateFontFile) {
     auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
     EXPECT_TRUE(config != nullptr);
     EXPECT_TRUE(Altseed2::Core::Initialize(u"GenerateFontFile", 600, 400, config));
+    EXPECT_TRUE(Altseed2::FileSystem::IsDirectory(u"TestData/Font"));
     EXPECT_TRUE(
             Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/test.a2f", 100, u"Hello, world! こんにちは"));
+            
+    EXPECT_FALSE(Altseed2::FileSystem::IsDirectory(u"TestData/Font/NotExistedDirectory"));
     EXPECT_FALSE(
             Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/NotExistedDirectory/test.a2f", 100, u"Hello, world! こんにちは"));
     Altseed2::Core::Terminate();

--- a/core/test/Font.cpp
+++ b/core/test/Font.cpp
@@ -1,4 +1,4 @@
-﻿
+
 #include "Graphics/Font.h"
 
 #include <Core.h>
@@ -542,5 +542,17 @@ TEST(Font, Vertical) {
         Altseed2::CullingSystem::GetInstance()->Unregister(t);
     }
 
+    Altseed2::Core::Terminate();
+}
+
+
+TEST(Font, GenerateFontFile) {
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"GenerateFontFile", 600, 400, config));
+    EXPECT_TRUE(
+            Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/test.a2f", 100, u"Hello, world! こんにちは"));
+    EXPECT_FALSE(
+            Altseed2::Font::GenerateFontFile(u"TestData/Font/mplus-1m-regular.ttf", u"TestData/Font/NotExistedDirectory/test.a2f", 100, u"Hello, world! こんにちは"));
     Altseed2::Core::Terminate();
 }


### PR DESCRIPTION
##  Issue 関連URL

* https://github.com/altseed/Altseed2/issues/614


## 概要

### なぜこの変更をするのか

>System.Runtime.InteropServices.SEHException (0x80004005): External component has thrown an exception.
at Altseed2.Font.cbg_Font_GenerateFontFile(String dynamicFontPath, String staticFontPath, Int32 size, String characters)
at Altseed2.Font.GenerateFontFile(String dynamicFontPath, String staticFontPath, Int32 size, String characters)
 <StartupCode$FSI_0003>.$FSI_0003.main@()
エラーのため停止しました


という状況をなくすためである.


### これによってどう解決されるのか

GenerateFontFileで出力先のディレクトリが存在しない場合, Logを出してfalseを返すことで, 
上記の状況を解決します.



## 技術的変更点概要

* なにをどう変更したか

- [ ]  https://github.com/altseed/Altseed2/blob/master/core/src/Graphics/Font.cpp のGenerateFontFileの先頭に, コードを追加しました.
- [ ]  ログのメッセージですが、  u"Font::GenerateFontFile: うんたらかんたら" の形式に変更しました (GenerateFontFileの内部について).

- [ ] Altseed2/core/test/Font.cpp の末尾に, テストを追加しました.



## TDログ

* [ ]  GenerateFontFileの先頭に, GenerateFontFileで出力先のディレクトリが存在しない場合に関して,  ログを仕込みました.


## テスト結果とテスト項目

https://github.com/altseed/Altseed2/blob/088a0b030f796f659d2fa15f0a4b280cba02f51a/core/test/Font.cpp
にTESTを追加しました

<img width="722" alt="Screen Shot 2020-09-13 at 16 48 51" src="https://user-images.githubusercontent.com/52277348/93013390-0ba58680-f5e3-11ea-8e9b-32eec91b3d8a.png">


* [ ] GenerateFontFileで出力先のディレクトリが存在する場合
* [ ] GenerateFontFileで出力先のディレクトリが存在しない場合
それぞれ1例ずつチェックしています.

## その他

* レビュワーに対する注意点
* [ ] 初めての作業のため, 至らない所あると思いますが何卒宜しくお願いします
（改善点は真摯に受け止め反省したいと思います. ご指摘いただけると幸いです.）.

とくに,
  - log messageがこれでよさそうか, 別の表現のほうが良いでしょうか？？
  - コード中にテストを追加した位置について: コードの末尾に挿入したが, 他の場所のほうが適切でしょうか？

* [ ] Some checks were not successful
1 failing, 2 in progress, and 1 successful checksという表示が, このプルリクエスト欄の下に表示されています. 大丈夫でしょうか？？
