### PR TITLE
add Error check to ShaderCompiler::Compile

### DIFF
--- a/core/src/Graphics/ShaderCompiler/ShaderCompiler.cpp
+++ b/core/src/Graphics/ShaderCompiler/ShaderCompiler.cpp
@@ -66,6 +66,12 @@ std::shared_ptr<ShaderCompileResult> ShaderCompiler::Compile(const char* path, c
     auto spirv = spirvGenerator_->Generate(path, code, macros, static_cast<LLGI::ShaderStageType>(shaderStage), true);
 #endif
 
+    if (spirv->GetData().empty()) {
+        Log::GetInstance()->Error(LogCategory::Core, u"ShaderCompiler::Compile: parse error {0} : {1}", name, spirv->GetError());
+        Log::GetInstance()->Error(LogCategory::Core, u"Code :\n{}", code);
+        return MakeAsdShared<ShaderCompileResult>(nullptr, utf8_to_utf16(spirv->GetError()));
+    }
+
     // convert a code or use raw code
     if (spirvTranspiler_ != nullptr) {
         if (!spirvTranspiler_->Transpile(spirv)) {

--- a/core/test/Graphics.cpp
+++ b/core/test/Graphics.cpp
@@ -1278,3 +1278,16 @@ TEST(Graphics, MassDrawCall) {
     }
     Altseed2::Core::Terminate();
 }
+
+TEST(Graphics, CompileInvalidShaderCode) {
+    auto config = Altseed2TestConfig(Altseed2::CoreModules::Graphics);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"CompileInvalidShaderCode", 600, 400, config));
+
+    auto result = Altseed2::Shader::Compile(u"invalidShader", u"invalid shader code", Altseed2::ShaderStageType::Pixel);
+
+    EXPECT_TRUE(result->GetValue() == nullptr);
+
+    Altseed2::Core::Terminate();
+}


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
invalidなShaderのコードをCompileしようとすると落ちるのを修正。

`spirvGenerator_->Generate` が失敗して返る `spirv: LLGI::SPIRV` の `data` は空のままになっているけど、呼び出し元でも `spirvTranspiler_->Transpile` 内でも `data` が空かどうか確かめてないから、SPIRV側でエラーが吐かれていた。

`spirvGenerator_->Generate`の結果の`spirv: SPIRV` の dataがemptyか確かめるようにした。

invalidなShaderCodeをコンパイルするtestも追加した。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->

