### PR TITLE
add null check to Collider::GetIsCollidedWith

### DIFF
--- a/core/src/Logger/Log.h
+++ b/core/src/Logger/Log.h
@@ -69,7 +69,7 @@ public:
 
     template <typename... Args>
     void Write(LogCategory category, LogLevel level, const char16_t* format, const Args&... args) {
-        if (!GetInstance()->enabledLogging_ || level == LogLevel::Off) return;
+        if (GetInstance() == nullptr || !GetInstance()->enabledLogging_ || level == LogLevel::Off) return;
 
         const auto logger = loggers_[static_cast<int32_t>(category)];
 

--- a/core/src/Physics/Collider/Collider.cpp
+++ b/core/src/Physics/Collider/Collider.cpp
@@ -1,5 +1,6 @@
 #include "Collider.h"
 
+#include "../../Logger/Log.h"
 #include "Box2DHelper.h"
 
 namespace Altseed2 {
@@ -41,6 +42,8 @@ void Collider::SetTransform(const Matrix44F& transform) {
 }
 
 bool Collider::GetIsCollidedWith(const std::shared_ptr<Collider>& collider) {
+    RETURN_IF_NULL(collider, false);
+
     auto selfShapes = GetB2Shapes();
     auto otherShapes = collider->GetB2Shapes();
 

--- a/core/test/Physics.cpp
+++ b/core/test/Physics.cpp
@@ -1,3 +1,4 @@
+#include <Core.h>
 #include <Physics/Collider/CircleCollider.h>
 #include <Physics/Collider/PolygonCollider.h>
 #include <Physics/Collider/ShapeCollider.h>
@@ -5,11 +6,21 @@
 
 #include <memory>
 
+#include "TestHelper.h"
+
 TEST(Physics, CollisionWithNull) {
+    auto coreModules = Altseed2::CoreModules::Window | Altseed2::CoreModules::File | Altseed2::CoreModules::Keyboard | Altseed2::CoreModules::Mouse | Altseed2::CoreModules::Joystick | Altseed2::CoreModules::Joystick | Altseed2::CoreModules::Graphics;
+    auto config = Altseed2TestConfig(coreModules);
+    EXPECT_TRUE(config != nullptr);
+
+    EXPECT_TRUE(Altseed2::Core::Initialize(u"test", 640, 480, config));
+
     auto collider1 = Altseed2::MakeAsdShared<Altseed2::CircleCollider>();
     collider1->SetPosition(Altseed2::Vector2F(100, 100));
     collider1->SetRadius(250);
     EXPECT_FALSE(collider1->GetIsCollidedWith(nullptr));
+
+    Altseed2::Core::Terminate();
 }
 
 TEST(Physics, CollisionWithCircles) {

--- a/core/test/Physics.cpp
+++ b/core/test/Physics.cpp
@@ -5,6 +5,13 @@
 
 #include <memory>
 
+TEST(Physics, CollisionWithNull) {
+    auto collider1 = Altseed2::MakeAsdShared<Altseed2::CircleCollider>();
+    collider1->SetPosition(Altseed2::Vector2F(100, 100));
+    collider1->SetRadius(250);
+    EXPECT_FALSE(collider1->GetIsCollidedWith(nullptr));
+}
+
 TEST(Physics, CollisionWithCircles) {
     auto collider1 = Altseed2::MakeAsdShared<Altseed2::CircleCollider>();
     auto collider2 = Altseed2::MakeAsdShared<Altseed2::CircleCollider>();


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
`Collider::GetIsCollidedWith` に nullptr のチェックを追加した。
Physics の test に `CollisionWithNull` を追加した。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/692
