### PR TITLE
shape.orientContours

### DIFF
--- a/core/src/Graphics/Font.cpp
+++ b/core/src/Graphics/Font.cpp
@@ -389,6 +389,7 @@ void Font::AddGlyph(const int32_t character) {
     {
         shape.inverseYAxis = !shape.inverseYAxis;
         shape.normalize();
+        shape.orientContours();
         msdfgen::edgeColoringSimple(shape, AngleThresholdDefault);
 
         msdfgen::generateMSDF(msdf, shape, PxRangeDefault, scale, msdfgen::Vector2(0.0, -descent_));


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->

> reputeless  17:19
一部の文字でその現象が出たので、必ず orientContours() するようにしたら、そのケースは解決しました。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/694
