### PR TITLE
fix MediaPlayer to use RenderTexture

### DIFF
--- a/core/src/AutoGeneratedCoreWrapper.cpp
+++ b/core/src/AutoGeneratedCoreWrapper.cpp
@@ -3016,11 +3016,11 @@ CBGEXPORT bool CBGSTDCALL cbg_MediaPlayer_Play(void* cbg_self, bool isLoopingMod
     return cbg_ret;
 }
 
-CBGEXPORT bool CBGSTDCALL cbg_MediaPlayer_WriteToTexture2D(void* cbg_self, void* target) {
+CBGEXPORT bool CBGSTDCALL cbg_MediaPlayer_WriteToRenderTexture(void* cbg_self, void* target) {
     auto cbg_self_ = (Altseed2::MediaPlayer*)(cbg_self);
 
-    std::shared_ptr<Altseed2::Texture2D> cbg_arg0 = Altseed2::CreateAndAddSharedPtr<Altseed2::Texture2D>((Altseed2::Texture2D*)target);
-    bool cbg_ret = cbg_self_->WriteToTexture2D(cbg_arg0);
+    std::shared_ptr<Altseed2::RenderTexture> cbg_arg0 = Altseed2::CreateAndAddSharedPtr<Altseed2::RenderTexture>((Altseed2::RenderTexture*)target);
+    bool cbg_ret = cbg_self_->WriteToRenderTexture(cbg_arg0);
     return cbg_ret;
 }
 

--- a/core/src/Media/MediaPlayer.cpp
+++ b/core/src/Media/MediaPlayer.cpp
@@ -27,8 +27,8 @@ bool MediaPlayer::Play(bool isLoopingMode) {
     return impl_->Play(isLoopingMode);
 }
 
-bool MediaPlayer::WriteToTexture2D(std::shared_ptr<Texture2D> target) {
-    return impl_->WriteToTexture2D(target);
+bool MediaPlayer::WriteToRenderTexture(std::shared_ptr<RenderTexture> target) {
+    return impl_->WriteToRenderTexture(target);
 }
 
 Vector2I MediaPlayer::GetSize() const {

--- a/core/src/Media/MediaPlayer.h
+++ b/core/src/Media/MediaPlayer.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "../Graphics/Texture2D.h"
+#include "../Graphics/RenderTexture.h"
 #include "../Math/Vector2I.h"
 
 namespace Altseed2 {
@@ -21,7 +21,7 @@ public:
 
     bool Play(bool isLoopingMode);
 
-    bool WriteToTexture2D(std::shared_ptr<Texture2D> target);
+    bool WriteToRenderTexture(std::shared_ptr<RenderTexture> target);
 
     Vector2I GetSize() const;
 

--- a/core/src/Media/Platform/MediaPlayer_AVF.h
+++ b/core/src/Media/Platform/MediaPlayer_AVF.h
@@ -25,7 +25,7 @@ public:
 
     int32_t GetCurrentFrame() const override;
 
-    bool WriteToTexture2D(std::shared_ptr<Texture2D> target) override;
+    bool WriteToRenderTexture(std::shared_ptr<RenderTexture> target) override;
 };
 
 }  // namespace Altseed2

--- a/core/src/Media/Platform/MediaPlayer_AVF.mm
+++ b/core/src/Media/Platform/MediaPlayer_AVF.mm
@@ -273,7 +273,7 @@ int32_t MediaPlayer_AVF::GetCurrentFrame() const
     return impl_->getCurrentFrame();
 }
 
-bool MediaPlayer_AVF::WriteToTexture2D(std::shared_ptr<Texture2D> target)
+bool MediaPlayer_AVF::WriteToRenderTexture(std::shared_ptr<RenderTexture> target)
 {
     if (target == nullptr)
         return false;

--- a/core/src/Media/Platform/MediaPlayer_FFmpeg.cpp
+++ b/core/src/Media/Platform/MediaPlayer_FFmpeg.cpp
@@ -142,7 +142,7 @@ Vector2I MediaPlayer_FFmpeg::GetSize() const { return size_; }
 
 int32_t MediaPlayer_FFmpeg::GetCurrentFrame() const { return currentFrame_; }
 
-bool MediaPlayer_FFmpeg::WriteToTexture2D(std::shared_ptr<Texture2D> target) {
+bool MediaPlayer_FFmpeg::WriteToRenderTexture(std::shared_ptr<RenderTexture> target) {
     if (target == nullptr)
         return false;
     if (target->GetSize() != GetSize())

--- a/core/src/Media/Platform/MediaPlayer_FFmpeg.h
+++ b/core/src/Media/Platform/MediaPlayer_FFmpeg.h
@@ -39,7 +39,7 @@ public:
 
     int32_t GetCurrentFrame() const override;
 
-    bool WriteToTexture2D(std::shared_ptr<Texture2D> target) override;
+    bool WriteToRenderTexture(std::shared_ptr<RenderTexture> target) override;
 };
 
 }  // namespace Altseed2

--- a/core/src/Media/Platform/MediaPlayer_Impl.h
+++ b/core/src/Media/Platform/MediaPlayer_Impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../Graphics/Graphics.h"
+#include "../../Graphics/RenderTexture.h"
 #include "../../Math/Vector2I.h"
 
 namespace Altseed2 {
@@ -15,7 +16,7 @@ public:
 
     virtual int32_t GetCurrentFrame() const = 0;
 
-    virtual bool WriteToTexture2D(std::shared_ptr<Texture2D> target) = 0;
+    virtual bool WriteToRenderTexture(std::shared_ptr<RenderTexture> target) = 0;
 };
 
 }  // namespace Altseed2

--- a/core/src/Media/Platform/MediaPlayer_WMF.cpp
+++ b/core/src/Media/Platform/MediaPlayer_WMF.cpp
@@ -249,7 +249,7 @@ Vector2I MediaPlayer_WMF::GetSize() const { return size_; }
 
 int32_t MediaPlayer_WMF::GetCurrentFrame() const { return currentFrame; }
 
-bool MediaPlayer_WMF::WriteToTexture2D(std::shared_ptr<Texture2D> target) {
+bool MediaPlayer_WMF::WriteToRenderTexture(std::shared_ptr<RenderTexture> target) {
     if (target == nullptr)
         return false;
     if (target->GetSize() != GetSize())

--- a/core/src/Media/Platform/MediaPlayer_WMF.h
+++ b/core/src/Media/Platform/MediaPlayer_WMF.h
@@ -45,7 +45,7 @@ public:
 
     int32_t GetCurrentFrame() const override;
 
-    bool WriteToTexture2D(std::shared_ptr<Texture2D> target) override;
+    bool WriteToRenderTexture(std::shared_ptr<RenderTexture> target) override;
 };
 
 }  // namespace Altseed2

--- a/core/test/Movie.cpp
+++ b/core/test/Movie.cpp
@@ -21,7 +21,7 @@ TEST(Movie, Basic) {
 
     auto instance = Altseed2::Graphics::GetInstance();
 
-    auto t1 = Altseed2::Texture2D::Create({640, 480});
+    auto t1 = Altseed2::RenderTexture::Create({640, 480});
 
     auto movie = Altseed2::MediaPlayer::Load(u"TestData/Movie/Test1.mp4");
 
@@ -37,7 +37,7 @@ TEST(Movie, Basic) {
     s1->SetSrc(Altseed2::RectF(0, 0, 640, 480));
 
     while (count++ < 10 && instance->DoEvents() && Altseed2::Core::GetInstance()->DoEvent()) {
-        movie->WriteToTexture2D(t1);
+        movie->WriteToRenderTexture(t1);
 
         Altseed2::CullingSystem::GetInstance()->UpdateAABB();
         Altseed2::CullingSystem::GetInstance()->Cull(Altseed2::RectF(Altseed2::Vector2F(), Altseed2::Window::GetInstance()->GetSize().To2F()));

--- a/scripts/bindings/auto_generate_define.py
+++ b/scripts/bindings/auto_generate_define.py
@@ -2294,9 +2294,9 @@ with MediaPlayer as class_:
         with func_.add_arg(bool, 'isLoopingMode') as arg:
             pass
 
-    with class_.add_func('WriteToTexture2D') as func_:
+    with class_.add_func('WriteToRenderTexture') as func_:
         func_.return_value.type_ = bool
-        with func_.add_arg(Texture2D, 'target') as arg:
+        with func_.add_arg(RenderTexture, 'target') as arg:
             pass
 
     with class_.add_func('Load') as func_:

--- a/scripts/bindings/desc_media.json
+++ b/scripts/bindings/desc_media.json
@@ -8,7 +8,7 @@
                     "@brief": "ループ再生するか?"
                 }
             },
-            "WriteToTexture2D": {
+            "WriteToRenderTexture": {
                 "@brief": "現在の映像のフレームをテクスチャに書き込みます。映像とテクスチャは同じサイズである必要があります。",
                 "target": {
                     "@brief": "テクスチャ"


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
MediaPlayerが`Texture2D`に書き込む実装となっているが、Altseed2では`Texture2D`は画像ファイルから読み込んだ画像を表すクラスであり、書き込む対象のテクスチャとしては`RenderTexture`クラスが存在する。APIの一貫性的に、`MediaPlayer`の書き込む対象を`RenderTexture`にしたい。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->

