### PR TITLE
fix sound.soundloop

### DIFF
--- a/core/test/Sound.cpp
+++ b/core/test/Sound.cpp
@@ -57,9 +57,9 @@ TEST(Sound, SoundLoop) {
     clock_t start = clock();
 
     while (asd::Core::GetInstance()->DoEvent() && mixer->GetIsPlaying(id_bgm)) {
-        double time = (clock() - start) * 0.01;
+        double time = (clock() - start) / CLOCKS_PER_SEC;
 
-        if (time > 5000) mixer->Stop(id_bgm);
+        if (time > 5) mixer->Stop(id_bgm);
     }
 
     asd::Core::Terminate();


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
Sound.SoundLoopのテスト実行時間がとても長かったので5秒で終わるようにした。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->

